### PR TITLE
Add `cases()` to enumerations and `definitions()` to dictionaries

### DIFF
--- a/lib/lk-util/Catalog/EnvVar.php
+++ b/lib/lk-util/Catalog/EnvVar.php
@@ -7,6 +7,7 @@ use Lkrms\Concept\Dictionary;
 /**
  * Environment variables used by lk-util commands
  *
+ * @extends Dictionary<string>
  */
 final class EnvVar extends Dictionary
 {

--- a/src/Cli/Catalog/CliHelpSectionName.php
+++ b/src/Cli/Catalog/CliHelpSectionName.php
@@ -7,6 +7,8 @@ use Lkrms\Concept\Dictionary;
 /**
  * Section names commonly used in usage information / help messages
  *
+ * @extends Dictionary<string>
+ *
  * @see \Lkrms\Cli\CliCommand::getHelpSections()
  */
 final class CliHelpSectionName extends Dictionary

--- a/src/Concept/Dictionary.php
+++ b/src/Concept/Dictionary.php
@@ -2,13 +2,22 @@
 
 namespace Lkrms\Concept;
 
+use Lkrms\Concern\IsCatalog;
 use Lkrms\Contract\IDictionary;
 
 /**
  * Base class for dictionaries
  *
+ * @template TValue
+ *
+ * @implements IDictionary<TValue>
  */
 abstract class Dictionary implements IDictionary
 {
-    final private function __construct() {}
+    /**
+     * @use IsCatalog<TValue>
+     */
+    use IsCatalog {
+        constants as definitions;
+    }
 }

--- a/src/Concept/Enumeration.php
+++ b/src/Concept/Enumeration.php
@@ -2,6 +2,7 @@
 
 namespace Lkrms\Concept;
 
+use Lkrms\Concern\IsCatalog;
 use Lkrms\Contract\IEnumeration;
 
 /**
@@ -13,5 +14,10 @@ use Lkrms\Contract\IEnumeration;
  */
 abstract class Enumeration implements IEnumeration
 {
-    final private function __construct() {}
+    /**
+     * @use IsCatalog<TValue>
+     */
+    use IsCatalog {
+        constants as cases;
+    }
 }

--- a/src/Concern/IsCatalog.php
+++ b/src/Concern/IsCatalog.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\Concern;
+
+use ReflectionClass;
+
+/**
+ * Has public constants with values of a given type, and cannot be instantiated
+ *
+ * @template TValue
+ */
+trait IsCatalog
+{
+    /**
+     * @var array<class-string<static>,array<string,TValue>>
+     */
+    private static array $Constants = [];
+
+    /**
+     * @return array<string,TValue>
+     */
+    public static function constants(): array
+    {
+        return self::$Constants[static::class]
+            ?? (self::$Constants[static::class] = self::getConstants());
+    }
+
+    /**
+     * @return array<string,TValue>
+     */
+    private static function getConstants(): array
+    {
+        $_constants = (new ReflectionClass(static::class))->getReflectionConstants();
+        foreach ($_constants as $_constant) {
+            if ($_constant->isPublic()) {
+                $constants[$_constant->getName()] = $_constant->getValue();
+            }
+        }
+        return $constants ?? [];
+    }
+
+    final private function __construct() {}
+}

--- a/src/Contract/IConvertibleEnumeration.php
+++ b/src/Contract/IConvertibleEnumeration.php
@@ -24,11 +24,4 @@ interface IConvertibleEnumeration extends IEnumeration
      * @param TValue $value
      */
     public static function toName($value): string;
-
-    /**
-     * Get an array that maps constant names to values
-     *
-     * @return array<string,TValue>
-     */
-    public static function cases(): array;
 }

--- a/src/Contract/IDictionary.php
+++ b/src/Contract/IDictionary.php
@@ -3,7 +3,16 @@
 namespace Lkrms\Contract;
 
 /**
- * Defines public constants with values of the same type
+ * Has public constants with values of a given type
  *
+ * @template TValue
  */
-interface IDictionary {}
+interface IDictionary
+{
+    /**
+     * Get an array that maps constant names to values
+     *
+     * @return array<string,TValue>
+     */
+    public static function definitions(): array;
+}

--- a/src/Contract/IEnumeration.php
+++ b/src/Contract/IEnumeration.php
@@ -3,8 +3,16 @@
 namespace Lkrms\Contract;
 
 /**
- * Has public constants with unique values
+ * Has public constants with unique values of a given type
  *
  * @template TValue
  */
-interface IEnumeration {}
+interface IEnumeration
+{
+    /**
+     * Get an array that maps constant names to values
+     *
+     * @return array<string,TValue>
+     */
+    public static function cases(): array;
+}

--- a/src/Support/Catalog/HttpHeader.php
+++ b/src/Support/Catalog/HttpHeader.php
@@ -7,6 +7,7 @@ use Lkrms\Concept\Dictionary;
 /**
  * Frequently-used HTTP headers
  *
+ * @extends Dictionary<string>
  */
 final class HttpHeader extends Dictionary
 {

--- a/src/Support/Catalog/HttpRequestMethod.php
+++ b/src/Support/Catalog/HttpRequestMethod.php
@@ -7,6 +7,8 @@ use Lkrms\Concept\Dictionary;
 /**
  * HTTP request methods
  *
+ * @extends Dictionary<string>
+ *
  * @see HttpRequestMethods::ALL
  */
 final class HttpRequestMethod extends Dictionary

--- a/src/Support/Catalog/HttpRequestMethods.php
+++ b/src/Support/Catalog/HttpRequestMethods.php
@@ -7,11 +7,12 @@ use Lkrms\Concept\Dictionary;
 /**
  * Groups of HTTP request methods
  *
+ * @extends Dictionary<array<HttpRequestMethod::*>>
  */
 final class HttpRequestMethods extends Dictionary
 {
     /**
-     * @phpstan-var array<HttpRequestMethod::*>
+     * @var array<HttpRequestMethod::*>
      */
     const ALL = [
         HttpRequestMethod::GET,

--- a/src/Support/Catalog/MimeType.php
+++ b/src/Support/Catalog/MimeType.php
@@ -8,6 +8,7 @@ use Lkrms\Utility\Convert;
 /**
  * Frequently-used MIME types
  *
+ * @extends Dictionary<string>
  */
 final class MimeType extends Dictionary
 {

--- a/src/Support/Catalog/RegularExpression.php
+++ b/src/Support/Catalog/RegularExpression.php
@@ -7,6 +7,7 @@ use Lkrms\Concept\Dictionary;
 /**
  * Useful PCRE regular expressions
  *
+ * @extends Dictionary<string>
  */
 final class RegularExpression extends Dictionary
 {

--- a/src/Support/Catalog/TtyControlSequence.php
+++ b/src/Support/Catalog/TtyControlSequence.php
@@ -7,6 +7,7 @@ use Lkrms\Concept\Dictionary;
 /**
  * Terminal control sequences
  *
+ * @extends Dictionary<string>
  */
 final class TtyControlSequence extends Dictionary
 {


### PR DESCRIPTION
- Add `TValue` template to `IDictionary` and related classes
- Add `cases()` and `definitions()` to `IDictionary`, `IEnumeration`, and related classes
- Add `IsCatalog` trait to remove duplicated code in abstract `Dictionary` and `Enumeration` classes