### PR TITLE
Fix regression in File::getEol(), deprecate Convert::lineEndingsToUnix()

### DIFF
--- a/src/Console/ConsoleFormatter.php
+++ b/src/Console/ConsoleFormatter.php
@@ -250,7 +250,7 @@ final class ConsoleFormatter
         // fenced code blocks and code spans
         if (!Pcre::matchAll(
             Regex::delimit(self::PARSER_REGEX) . 'u',
-            Convert::lineEndingsToUnix($string),
+            Str::setEol($string),
             $matches,
             PREG_SET_ORDER | PREG_UNMATCHED_AS_NULL
         )) {

--- a/src/Support/PhpDoc/PhpDoc.php
+++ b/src/Support/PhpDoc/PhpDoc.php
@@ -6,6 +6,7 @@ use Lkrms\Concern\TFullyReadable;
 use Lkrms\Contract\IReadable;
 use Lkrms\Support\Catalog\RegularExpression as Regex;
 use Lkrms\Utility\Convert;
+use Lkrms\Utility\Str;
 use UnexpectedValueException;
 
 /**
@@ -141,7 +142,7 @@ final class PhpDoc implements IReadable
                     '/(^\h*\* ?|\h+$)/um',
                     '',
                     // 2. Normalise line endings
-                    Convert::lineEndingsToUnix(
+                    Str::setEol(
                         // 1. Extract text between "/**" and "*/"
                         $matches['content']
                     )

--- a/src/Utility/Convert.php
+++ b/src/Utility/Convert.php
@@ -1340,6 +1340,7 @@ final class Convert
     /**
      * Replace a string's CRLF or CR end-of-line sequences with LF
      *
+     * @deprecated Use {@see Str::setEol()} instead
      */
     public static function lineEndingsToUnix(string $string): string
     {

--- a/src/Utility/Env.php
+++ b/src/Utility/Env.php
@@ -60,7 +60,7 @@ final class Env
         $queue = [];
         $errors = [];
         foreach ($path as $filename) {
-            $lines = explode("\n", Convert::lineEndingsToUnix(file_get_contents($filename)));
+            $lines = explode("\n", Str::setEol(file_get_contents($filename)));
             self::parse($lines, $queue, $errors, $filename);
         }
         self::doLoad($queue, $errors);

--- a/src/Utility/Filesystem.php
+++ b/src/Utility/Filesystem.php
@@ -152,12 +152,6 @@ final class Filesystem
      */
     public function getEol(string $filename): ?string
     {
-        // Enable PHP's detection of CR line endings
-        $restore = ini_set('auto_detect_line_endings', '1');
-        if ($restore === false || $restore) {
-            $restore = null;
-        }
-
         if (($f = fopen($filename, 'r')) === false ||
                 ($line = fgets($f)) === false ||
                 fclose($f) === false) {
@@ -170,8 +164,8 @@ final class Filesystem
             }
         }
 
-        if ($restore !== null) {
-            ini_set('auto_detect_line_endings', $restore);
+        if (strpos($line, "\r") !== false) {
+            return "\r";
         }
 
         return null;

--- a/src/Utility/Reflection.php
+++ b/src/Utility/Reflection.php
@@ -162,13 +162,13 @@ final class Reflection
         $comments = [];
         do {
             if (($comment = $class->getDocComment()) !== false) {
-                $comments[$class->getName()] = Convert::lineEndingsToUnix($comment);
+                $comments[$class->getName()] = Str::setEol($comment);
             }
         } while ($class = $class->getParentClass());
 
         foreach ($interfaces as $interface) {
             if (($comment = $interface->getDocComment()) !== false) {
-                $comments[$interface->getName()] = Convert::lineEndingsToUnix($comment);
+                $comments[$interface->getName()] = Str::setEol($comment);
             }
         }
 
@@ -201,10 +201,10 @@ final class Reflection
             if ($interface->hasMethod($name) &&
                     ($comment = $interface->getMethod($name)->getDocComment()) !== false) {
                 $class = $interface->getName();
-                $comments[$class] = Convert::lineEndingsToUnix($comment);
+                $comments[$class] = Str::setEol($comment);
                 if (!is_null($classDocComments)) {
                     $comment = $interface->getDocComment() ?: null;
-                    $classDocComments[$class] = $comment === null ? null : Convert::lineEndingsToUnix($comment);
+                    $classDocComments[$class] = $comment === null ? null : Str::setEol($comment);
                 }
             }
         }
@@ -223,10 +223,10 @@ final class Reflection
         do {
             if (($comment = $method->getDocComment()) !== false) {
                 $class = $method->getDeclaringClass()->getName();
-                $comments[$class] = Convert::lineEndingsToUnix($comment);
+                $comments[$class] = Str::setEol($comment);
                 if (!is_null($classDocComments)) {
                     $comment = $method->getDeclaringClass()->getDocComment() ?: null;
-                    $classDocComments[$class] = $comment === null ? null : Convert::lineEndingsToUnix($comment);
+                    $classDocComments[$class] = $comment === null ? null : Str::setEol($comment);
                 }
             }
             // Interfaces don't have traits, so there's nothing else to do here
@@ -293,10 +293,10 @@ final class Reflection
         do {
             if (($comment = $property->getDocComment()) !== false) {
                 $class = $property->getDeclaringClass()->getName();
-                $comments[$class] = Convert::lineEndingsToUnix($comment);
+                $comments[$class] = Str::setEol($comment);
                 if (!is_null($classDocComments)) {
                     $comment = $property->getDeclaringClass()->getDocComment() ?: null;
-                    $classDocComments[$class] = $comment === null ? null : Convert::lineEndingsToUnix($comment);
+                    $classDocComments[$class] = $comment === null ? null : Str::setEol($comment);
                 }
             }
             foreach ($property->getDeclaringClass()->getTraits() as $trait) {

--- a/src/Utility/Str.php
+++ b/src/Utility/Str.php
@@ -52,7 +52,7 @@ final class Str
      */
     public static function setEol(
         string $string,
-        string $eol = PHP_EOL
+        string $eol = "\n"
     ): string {
         switch ($eol) {
             case "\n":

--- a/tests/unit/Polyfill/PhpTokenTest.php
+++ b/tests/unit/Polyfill/PhpTokenTest.php
@@ -4,6 +4,7 @@ namespace Lkrms\Tests\Polyfill;
 
 use Lkrms\Polyfill\PhpToken;
 use Lkrms\Utility\Convert;
+use Lkrms\Utility\Str;
 
 final class PhpTokenTest extends \Lkrms\Tests\TestCase
 {
@@ -14,7 +15,7 @@ final class PhpTokenTest extends \Lkrms\Tests\TestCase
      */
     public function testTokenize(string $input, array $expected)
     {
-        $actual = PhpToken::tokenize(Convert::lineEndingsToUnix($input), TOKEN_PARSE);
+        $actual = PhpToken::tokenize(Str::setEol($input), TOKEN_PARSE);
         $actualCode = array_reduce(
             $actual,
             fn(string $code, PhpToken $token) => sprintf(


### PR DESCRIPTION
- Remove use of deprecated `auto_detect_line_endings` setting
- Adopt `Str::setEol()` over `Convert::lineEndingsToUnix()`