### PR TITLE
Sync: fix sync operation return type regressions

### DIFF
--- a/src/Sync/Contract/ISyncDefinition.php
+++ b/src/Sync/Contract/ISyncDefinition.php
@@ -3,7 +3,6 @@
 namespace Lkrms\Sync\Contract;
 
 use Lkrms\Contract\IImmutable;
-use Lkrms\Support\Iterator\Contract\FluentIteratorInterface;
 use Lkrms\Sync\Catalog\SyncOperation;
 use Closure;
 
@@ -21,17 +20,17 @@ interface ISyncDefinition extends IImmutable
      * entity
      *
      * @param SyncOperation::* $operation
-     * @return (Closure(ISyncContext, mixed...): FluentIteratorInterface<array-key,TEntity>|TEntity)|null `null` if `$operation` is not supported, otherwise a closure with the correct signature for the sync operation.
+     * @return (Closure(ISyncContext, mixed...): (iterable<TEntity>|TEntity))|null `null` if `$operation` is not supported, otherwise a closure with the correct signature for the sync operation.
      * @phpstan-return (
      *     $operation is SyncOperation::READ
      *     ? (Closure(ISyncContext, int|string|null, mixed...): TEntity)
      *     : (
      *         $operation is SyncOperation::READ_LIST
-     *         ? (Closure(ISyncContext, mixed...): FluentIteratorInterface<array-key,TEntity>)
+     *         ? (Closure(ISyncContext, mixed...): iterable<TEntity>)
      *         : (
      *             $operation is SyncOperation::CREATE|SyncOperation::UPDATE|SyncOperation::DELETE
      *             ? (Closure(ISyncContext, TEntity, mixed...): TEntity)
-     *             : (Closure(ISyncContext, FluentIteratorInterface<array-key,TEntity>, mixed...): FluentIteratorInterface<array-key,TEntity>)
+     *             : (Closure(ISyncContext, iterable<TEntity>, mixed...): iterable<TEntity>)
      *         )
      *     )
      * )|null

--- a/src/Sync/Support/SyncContext.php
+++ b/src/Sync/Support/SyncContext.php
@@ -209,12 +209,15 @@ final class SyncContext extends ProviderContext implements ISyncContext
                     return null;
                 }
                 $name = Convert::toSnakeCase(substr($key, 0, -3));
-                $key = $this->FilterKeys[$name] ?? null;
-                if ($key === null) {
+                if (array_key_exists($name, $this->FilterKeys)) {
+                    $key = $this->FilterKeys[$name];
+                    if ($claim) {
+                        unset($this->FilterKeys[$name]);
+                    }
+                } elseif (array_key_exists($name, $this->Filters)) {
+                    $key = $name;
+                } else {
                     return null;
-                }
-                if ($claim) {
-                    unset($this->FilterKeys[$name]);
                 }
             }
         }

--- a/src/Sync/Support/SyncEntityProvider.php
+++ b/src/Sync/Support/SyncEntityProvider.php
@@ -103,10 +103,10 @@ final class SyncEntityProvider implements ISyncEntityProvider
     /**
      * @param SyncOperation::* $operation
      * @param mixed ...$args
-     * @return FluentIteratorInterface<array-key,TEntity>|TEntity
+     * @return iterable<TEntity>|TEntity
      * @phpstan-return (
      *     $operation is SyncOperation::*_LIST
-     *     ? FluentIteratorInterface<array-key,TEntity>
+     *     ? iterable<TEntity>
      *     : TEntity
      * )
      */
@@ -460,9 +460,10 @@ final class SyncEntityProvider implements ISyncEntityProvider
 
         $fromCheckpoint = $this->Store->getDeferredEntityCheckpoint();
 
-        $result = iterator_to_array(
-            $this->_run($operation, ...$args)
-        );
+        $result = $this->_run($operation, ...$args);
+        if (!is_array($result)) {
+            $result = iterator_to_array($result);
+        }
 
         if ($this->Context->getDeferredSyncEntityPolicy() !==
                 DeferredEntityPolicy::DO_NOT_RESOLVE) {

--- a/src/Sync/Support/SyncIntrospector.php
+++ b/src/Sync/Support/SyncIntrospector.php
@@ -267,8 +267,8 @@ final class SyncIntrospector extends Introspector
      *
      * @param SyncOperation::* $operation
      * @param class-string<T>|static<T> $entity
+     * @return (Closure(ISyncContext, mixed...): (iterable<T>|T))|null
      *
-     * @return (Closure(ISyncContext, mixed...): mixed)|null
      * @throws LogicException if the {@see SyncIntrospector} and `$entity` don't
      * respectively represent an {@see ISyncProvider} and {@see ISyncEntity}.
      */


### PR DESCRIPTION
Also:
- Replace `SyncDefinition::getFallbackSyncOperationClosure()` with `SyncDefinition::getFallbackClosure()` and deprecate the former
- Add `SyncDefinition::withReadFromReadList()`
- Fix issue where filters without `_id` suffixes are not matched with parameters with names ending in `_id`