### PR TITLE
Sync: continue cleanup, improve sync definition API, fix bugs

### DIFF
--- a/src/Concept/Provider.php
+++ b/src/Concept/Provider.php
@@ -3,9 +3,9 @@
 namespace Lkrms\Concept;
 
 use Lkrms\Contract\IContainer;
+use Lkrms\Contract\IDateFormatter;
 use Lkrms\Contract\IProvider;
 use Lkrms\Exception\MethodNotImplementedException;
-use Lkrms\Support\DateFormatter;
 use Lkrms\Support\ProviderContext;
 use Lkrms\Utility\Env;
 
@@ -20,7 +20,7 @@ abstract class Provider implements IProvider
 
     protected Env $Env;
 
-    private DateFormatter $DateFormatter;
+    private IDateFormatter $DateFormatter;
 
     /**
      * Creates a new provider object
@@ -32,13 +32,13 @@ abstract class Provider implements IProvider
     }
 
     /**
-     * Get a DateFormatter to work with the backend's date format and/or
-     * timezone
+     * Get a date formatter to work with the backend's date and time format
+     * and/or timezone
      *
-     * The {@see DateFormatter} returned will be cached for the lifetime of the
+     * The {@see IDateFormatter} returned will be cached for the lifetime of the
      * {@see Provider} instance.
      */
-    abstract protected function getDateFormatter(): DateFormatter;
+    abstract protected function getDateFormatter(): IDateFormatter;
 
     /**
      * @inheritDoc
@@ -99,7 +99,7 @@ abstract class Provider implements IProvider
     /**
      * @inheritDoc
      */
-    final public function dateFormatter(): DateFormatter
+    final public function dateFormatter(): IDateFormatter
     {
         return $this->DateFormatter
             ?? ($this->DateFormatter = $this->getDateFormatter());

--- a/src/Contract/IProvider.php
+++ b/src/Contract/IProvider.php
@@ -3,7 +3,6 @@
 namespace Lkrms\Contract;
 
 use Lkrms\Exception\MethodNotImplementedException;
-use Lkrms\Support\DateFormatter;
 
 /**
  * Services objects on behalf of a backend
@@ -52,9 +51,10 @@ interface IProvider extends
     public function getBackendIdentifier(): array;
 
     /**
-     * Get a DateFormatter to work with the backend's date format and timezone
+     * Get a date formatter to work with the backend's date and time format
+     * and/or timezone
      */
-    public function dateFormatter(): DateFormatter;
+    public function dateFormatter(): IDateFormatter;
 
     /**
      * Throw an exception if the backend isn't reachable

--- a/src/Curler/Curler.php
+++ b/src/Curler/Curler.php
@@ -6,6 +6,7 @@ use Lkrms\Concern\HasBuilder;
 use Lkrms\Concern\HasMutator;
 use Lkrms\Concern\TReadable;
 use Lkrms\Concern\TWritable;
+use Lkrms\Contract\IDateFormatter;
 use Lkrms\Contract\IReadable;
 use Lkrms\Contract\IWritable;
 use Lkrms\Contract\ProvidesBuilder;
@@ -67,7 +68,7 @@ use RecursiveIteratorIterator;
  * @property bool $ExpectJson Request JSON from upstream?
  * @property bool $PostJson Use JSON to serialize POST/PUT/PATCH/DELETE data?
  * @property bool $PreserveKeys Suppress removal of numeric indices from serialized lists?
- * @property DateFormatter|null $DateFormatter Specify the date format and timezone used upstream
+ * @property IDateFormatter|null $DateFormatter Specify the date format and timezone used upstream
  * @property string|null $UserAgent Override the default User-Agent header
  * @property bool $AlwaysPaginate Pass every response to the pager?
  * @property bool $ObjectAsArray Return deserialized objects as associative arrays?
@@ -349,7 +350,7 @@ final class Curler implements IReadable, IWritable, ProvidesBuilder
     /**
      * Specify the date format and timezone used upstream
      *
-     * @var DateFormatter|null
+     * @var IDateFormatter|null
      */
     protected $DateFormatter;
 
@@ -428,7 +429,7 @@ final class Curler implements IReadable, IWritable, ProvidesBuilder
         bool $expectJson = true,
         bool $postJson = true,
         bool $preserveKeys = false,
-        ?DateFormatter $dateFormatter = null,
+        ?IDateFormatter $dateFormatter = null,
         ?string $userAgent = null,
         bool $alwaysPaginate = false,
         bool $objectAsArray = true
@@ -826,7 +827,7 @@ final class Curler implements IReadable, IWritable, ProvidesBuilder
                 continue;
             }
 
-            /** @var RecursiveHasChildrenCallbackIterator */
+            /** @var RecursiveHasChildrenCallbackIterator<array-key,mixed> */
             $inner = $iterator->getInnerIterator();
             /** @var RecursiveObjectOrArrayIterator */
             $inner = $inner->getInnerIterator();
@@ -869,7 +870,7 @@ final class Curler implements IReadable, IWritable, ProvidesBuilder
             : null;
     }
 
-    private function getDateFormatter(): DateFormatter
+    private function getDateFormatter(): IDateFormatter
     {
         return $this->DateFormatter
             ?: ($this->DateFormatter = new DateFormatter());

--- a/src/Curler/CurlerBuilder.php
+++ b/src/Curler/CurlerBuilder.php
@@ -3,10 +3,10 @@
 namespace Lkrms\Curler;
 
 use Lkrms\Concept\Builder;
+use Lkrms\Contract\IDateFormatter;
 use Lkrms\Curler\Catalog\CurlerProperty;
 use Lkrms\Curler\Contract\ICurlerHeaders;
 use Lkrms\Curler\Contract\ICurlerPager;
-use Lkrms\Support\DateFormatter;
 
 /**
  * Creates Curler objects via a fluent interface
@@ -32,7 +32,7 @@ use Lkrms\Support\DateFormatter;
  * @method $this expectJson(bool $value = true) Request JSON from upstream? (default: true)
  * @method $this postJson(bool $value = true) Use JSON to serialize POST/PUT/PATCH/DELETE data? (default: true)
  * @method $this preserveKeys(bool $value = true) Suppress removal of numeric indices from serialized lists? (default: false)
- * @method $this dateFormatter(?DateFormatter $value) Specify the date format and timezone used upstream
+ * @method $this dateFormatter(?IDateFormatter $value) Specify the date format and timezone used upstream
  * @method $this userAgent(?string $value) Override the default User-Agent header (see {@see Curler::$UserAgent})
  * @method $this alwaysPaginate(bool $value = true) Pass every response to the pager? (default: false)
  * @method $this objectAsArray(bool $value = true) Return deserialized objects as associative arrays? (default: true)

--- a/src/Support/Iterator/ObjectOrArrayIterator.php
+++ b/src/Support/Iterator/ObjectOrArrayIterator.php
@@ -3,17 +3,15 @@
 namespace Lkrms\Support\Iterator;
 
 use Lkrms\Support\Iterator\Contract\MutableIterator;
-use Iterator;
+use LogicException;
 use ReturnTypeWillChange;
-use RuntimeException;
 
 /**
  * Iterates over an object's properties or an array's elements
  *
- * @implements Iterator<array-key,mixed>
  * @implements MutableIterator<array-key,mixed>
  */
-class ObjectOrArrayIterator implements Iterator, MutableIterator
+class ObjectOrArrayIterator implements MutableIterator
 {
     /**
      * @var object|mixed[]
@@ -64,17 +62,15 @@ class ObjectOrArrayIterator implements Iterator, MutableIterator
     public function replace($value)
     {
         if (($key = current($this->Keys)) === false) {
-            throw new RuntimeException('Current position is not valid');
+            throw new LogicException('Current position is not valid');
         }
 
         if ($this->IsObject) {
             $this->ObjectOrArray->{$key} = $value;
-
             return $this;
         }
 
         $this->ObjectOrArray[$key] = $value;
-
         return $this;
     }
 
@@ -87,7 +83,6 @@ class ObjectOrArrayIterator implements Iterator, MutableIterator
         if (($key = current($this->Keys)) === false) {
             return null;
         }
-
         return $key;
     }
 

--- a/src/Support/Iterator/RecursiveHasChildrenCallbackIterator.php
+++ b/src/Support/Iterator/RecursiveHasChildrenCallbackIterator.php
@@ -48,17 +48,24 @@ class RecursiveHasChildrenCallbackIterator extends IteratorIterator implements R
             return false;
         }
 
-        $key = $this->Iterator->key();
-        $current = $this->Iterator->current();
-
-        return ($this->Callback)($current, $key, $this->Iterator);
+        return ($this->Callback)(
+            $this->Iterator->current(),
+            $this->Iterator->key(),
+            $this->Iterator,
+        );
     }
 
     /**
-     * @return RecursiveIterator<TKey,TValue>|null
+     * @return self<TKey,TValue>|null
      */
-    public function getChildren(): ?RecursiveIterator
+    public function getChildren(): ?self
     {
-        return $this->Iterator->getChildren();
+        /** @var RecursiveIterator<TKey,TValue>|null */
+        $children = $this->Iterator->getChildren();
+
+        return
+            $children === null
+                ? null
+                : new self($children, $this->Callback);
     }
 }

--- a/src/Support/Iterator/RecursiveObjectOrArrayIterator.php
+++ b/src/Support/Iterator/RecursiveObjectOrArrayIterator.php
@@ -45,7 +45,7 @@ class RecursiveObjectOrArrayIterator extends ObjectOrArrayIterator implements \R
      *
      * @return $this
      */
-    public function maybeReplaceCurrentWithArray()
+    public function maybeConvertToArray()
     {
         if (($current = $this->current()) === false) {
             return $this;

--- a/src/Support/Iterator/RecursiveObjectOrArrayIterator.php
+++ b/src/Support/Iterator/RecursiveObjectOrArrayIterator.php
@@ -43,13 +43,12 @@ class RecursiveObjectOrArrayIterator extends ObjectOrArrayIterator implements \R
      * If the current element is an object with children, replace it with an
      * array of its properties
      *
-     * @return mixed|false `false` if the current position is invalid, otherwise
-     * the current value.
+     * @return $this
      */
     public function maybeReplaceCurrentWithArray()
     {
         if (($current = $this->current()) === false) {
-            return false;
+            return $this;
         }
 
         if (is_object($current) && $this->hasChildren()) {
@@ -61,6 +60,6 @@ class RecursiveObjectOrArrayIterator extends ObjectOrArrayIterator implements \R
             return $this->replace($array);
         }
 
-        return $current;
+        return $this;
     }
 }

--- a/src/Sync/Concept/SyncProvider.php
+++ b/src/Sync/Concept/SyncProvider.php
@@ -125,6 +125,17 @@ abstract class SyncProvider extends Provider implements ISyncProvider, IService
     }
 
     /**
+     * Wrap a new pipeline around a callback
+     *
+     * @param (callable(mixed $payload, IPipeline<mixed,mixed,mixed> $pipeline, mixed $arg): mixed) $callback
+     * @return IPipeline<mixed,mixed,mixed>
+     */
+    final protected function callbackPipeline(callable $callback): IPipeline
+    {
+        return Pipeline::create($this->App)->throughCallback($callback);
+    }
+
+    /**
      * Use the provider's container to get a serialization rules builder
      * for an entity
      *

--- a/src/Sync/Support/DbSyncDefinition.php
+++ b/src/Sync/Support/DbSyncDefinition.php
@@ -44,7 +44,7 @@ final class DbSyncDefinition extends SyncDefinition implements ProvidesBuilder
      * @param array<OP::*> $operations
      * @param ArrayKeyConformity::* $conformity
      * @param SyncFilterPolicy::* $filterPolicy
-     * @param array<OP::*,Closure(DbSyncDefinition<TEntity,TProvider>, OP::*, ISyncContext, mixed...): mixed> $overrides
+     * @param array<int-mask-of<OP::*>,Closure(DbSyncDefinition<TEntity,TProvider>, OP::*, ISyncContext, mixed...): (iterable<TEntity>|TEntity)> $overrides
      * @param array<array-key,array-key|array-key[]>|null $keyMap
      * @param int-mask-of<ArrayMapperFlag::*> $keyMapFlags
      * @param IPipeline<mixed[],TEntity,array{0:OP::*,1:ISyncContext,2?:int|string|TEntity|TEntity[]|null,...}>|null $pipelineFromBackend

--- a/src/Sync/Support/DbSyncDefinitionBuilder.php
+++ b/src/Sync/Support/DbSyncDefinitionBuilder.php
@@ -25,7 +25,7 @@ use Closure;
  * @method $this table(?string $value) Set DbSyncDefinition::$Table
  * @method $this conformity(ArrayKeyConformity::* $value) The conformity level of data returned by the provider for this entity (see {@see SyncDefinition::$Conformity})
  * @method $this filterPolicy(SyncFilterPolicy::* $value) The action to take when filters are unclaimed by the provider (see {@see SyncDefinition::$FilterPolicy})
- * @method $this overrides(array<OP::*,Closure(DbSyncDefinition<TEntity,TProvider>, OP::*, ISyncContext, mixed...): mixed> $value) An array that maps sync operations to closures that override other implementations (see {@see SyncDefinition::$Overrides})
+ * @method $this overrides(array<int-mask-of<OP::*>,Closure(DbSyncDefinition<TEntity,TProvider>, OP::*, ISyncContext, mixed...): (iterable<TEntity>|TEntity)> $value) An array that maps sync operations to closures that override other implementations (see {@see SyncDefinition::$Overrides})
  * @method $this keyMap(array<array-key,array-key|array-key[]>|null $value) An array that maps provider (backend) keys to one or more entity keys (see {@see SyncDefinition::$KeyMap})
  * @method $this keyMapFlags(int-mask-of<ArrayMapperFlag::*> $value) Passed to the array mapper if `$keyMap` is provided
  * @method $this pipelineFromBackend(IPipeline<mixed[],TEntity,array{0:OP::*,1:ISyncContext,2?:int|string|TEntity|TEntity[]|null,...}>|null $value) A pipeline that maps data from the provider to entity-compatible associative arrays, or `null` if mapping is not required

--- a/src/Sync/Support/HttpSyncDefinition.php
+++ b/src/Sync/Support/HttpSyncDefinition.php
@@ -62,7 +62,7 @@ use UnexpectedValueException;
  * @property-read ICurlerHeaders|null $Headers HTTP headers applied to the sync operation request
  * @property-read ICurlerPager|null $Pager The pagination handler for the endpoint servicing the entity
  * @property-read int|null $Expiry The time, in seconds, before responses from the provider expire
- * @property-read array<OP::*,string> $MethodMap An array that maps sync operations to HTTP request methods
+ * @property-read array<OP::*,HttpRequestMethod::*> $MethodMap An array that maps sync operations to HTTP request methods
  * @property-read array<CurlerProperty::*,mixed> $CurlerProperties An array that maps Curler property names to values
  * @property-read bool $SyncOneEntityPerRequest If true, perform CREATE_LIST, UPDATE_LIST and DELETE_LIST operations on one entity per HTTP request
  * @property-read (callable(HttpSyncDefinition<TEntity,TProvider>, OP::*, ISyncContext, mixed...): HttpSyncDefinition<TEntity,TProvider>)|null $Callback A callback applied to the definition before every sync operation
@@ -192,7 +192,7 @@ final class HttpSyncDefinition extends SyncDefinition implements ProvidesBuilder
      * ]
      * ```
      *
-     * @var array<OP::*,string>
+     * @var array<OP::*,HttpRequestMethod::*>
      */
     protected $MethodMap;
 
@@ -239,7 +239,7 @@ final class HttpSyncDefinition extends SyncDefinition implements ProvidesBuilder
      * @param string[]|string|null $path
      * @param ArrayKeyConformity::* $conformity
      * @param SyncFilterPolicy::* $filterPolicy
-     * @param array<OP::*,Closure(HttpSyncDefinition<TEntity,TProvider>, OP::*, ISyncContext, mixed...): mixed> $overrides
+     * @param array<int-mask-of<OP::*>,Closure(HttpSyncDefinition<TEntity,TProvider>, OP::*, ISyncContext, mixed...): (iterable<TEntity>|TEntity)> $overrides
      * @param array<array-key,array-key|array-key[]>|null $keyMap
      * @param int-mask-of<ArrayMapperFlag::*> $keyMapFlags
      * @param IPipeline<mixed[],TEntity,array{0:OP::*,1:ISyncContext,2?:int|string|TEntity|TEntity[]|null,...}>|null $pipelineFromBackend
@@ -247,7 +247,7 @@ final class HttpSyncDefinition extends SyncDefinition implements ProvidesBuilder
      * @param SyncEntitySource::*|null $returnEntitiesFrom
      * @param mixed[]|null $query
      * @param (callable(HttpSyncDefinition<TEntity,TProvider>, OP::*, ISyncContext, mixed...): HttpSyncDefinition<TEntity,TProvider>)|null $callback
-     * @param array<OP::*,string> $methodMap
+     * @param array<OP::*,HttpRequestMethod::*> $methodMap
      * @param array<CurlerProperty::*,mixed> $curlerProperties
      */
     public function __construct(
@@ -374,7 +374,7 @@ final class HttpSyncDefinition extends SyncDefinition implements ProvidesBuilder
     /**
      * Replace the array that maps sync operations to HTTP request methods
      *
-     * @param array<OP::*,string> $methodMap
+     * @param array<OP::*,HttpRequestMethod::*> $methodMap
      * @return $this
      */
     public function withMethodMap(array $methodMap)

--- a/src/Sync/Support/HttpSyncDefinitionBuilder.php
+++ b/src/Sync/Support/HttpSyncDefinitionBuilder.php
@@ -9,6 +9,7 @@ use Lkrms\Curler\Contract\ICurlerHeaders;
 use Lkrms\Curler\Contract\ICurlerPager;
 use Lkrms\Support\Catalog\ArrayKeyConformity;
 use Lkrms\Support\Catalog\ArrayMapperFlag;
+use Lkrms\Support\Catalog\HttpRequestMethod;
 use Lkrms\Sync\Catalog\SyncEntitySource;
 use Lkrms\Sync\Catalog\SyncFilterPolicy;
 use Lkrms\Sync\Catalog\SyncOperation as OP;
@@ -33,10 +34,10 @@ use Closure;
  * @method $this conformity(ArrayKeyConformity::* $value) The conformity level of data returned by the provider for this entity (see {@see SyncDefinition::$Conformity})
  * @method $this filterPolicy(SyncFilterPolicy::* $value) The action to take when filters are unclaimed by the provider (see {@see SyncDefinition::$FilterPolicy})
  * @method $this expiry(?int $value) The time, in seconds, before responses from the provider expire (see {@see HttpSyncDefinition::$Expiry})
- * @method $this methodMap(array<OP::*,string> $value) An array that maps sync operations to HTTP request methods (see {@see HttpSyncDefinition::$MethodMap})
+ * @method $this methodMap(array<OP::*,HttpRequestMethod::*> $value) An array that maps sync operations to HTTP request methods (see {@see HttpSyncDefinition::$MethodMap})
  * @method $this curlerProperties(array<CurlerProperty::*,mixed> $value) An array that maps Curler property names to values (see {@see HttpSyncDefinition::$CurlerProperties})
  * @method $this syncOneEntityPerRequest(bool $value = true) If true, perform CREATE_LIST, UPDATE_LIST and DELETE_LIST operations on one entity per HTTP request (default: false)
- * @method $this overrides(array<OP::*,Closure(HttpSyncDefinition<TEntity,TProvider>, OP::*, ISyncContext, mixed...): mixed> $value) An array that maps sync operations to closures that override other implementations (see {@see SyncDefinition::$Overrides})
+ * @method $this overrides(array<int-mask-of<OP::*>,Closure(HttpSyncDefinition<TEntity,TProvider>, OP::*, ISyncContext, mixed...): (iterable<TEntity>|TEntity)> $value) An array that maps sync operations to closures that override other implementations (see {@see SyncDefinition::$Overrides})
  * @method $this keyMap(array<array-key,array-key|array-key[]>|null $value) An array that maps provider (backend) keys to one or more entity keys (see {@see SyncDefinition::$KeyMap})
  * @method $this keyMapFlags(int-mask-of<ArrayMapperFlag::*> $value) Passed to the array mapper if `$keyMap` is provided
  * @method $this pipelineFromBackend(IPipeline<mixed[],TEntity,array{0:OP::*,1:ISyncContext,2?:int|string|TEntity|TEntity[]|null,...}>|null $value) A pipeline that maps data from the provider to entity-compatible associative arrays, or `null` if mapping is not required

--- a/src/Utility/Convert.php
+++ b/src/Utility/Convert.php
@@ -2,6 +2,7 @@
 
 namespace Lkrms\Utility;
 
+use Lkrms\Contract\IDateFormatter;
 use Lkrms\Support\Catalog\RegularExpression as Regex;
 use Lkrms\Support\Iterator\Contract\MutableIterator;
 use Lkrms\Support\Iterator\RecursiveObjectOrArrayIterator;
@@ -1494,7 +1495,7 @@ final class Convert
     private static function _dataToQuery(
         array $data,
         bool $preserveKeys,
-        DateFormatter $dateFormatter,
+        IDateFormatter $dateFormatter,
         ?string &$query = null,
         string $name = '',
         string $format = '%s'
@@ -1543,7 +1544,7 @@ final class Convert
     public static function dataToQuery(
         array $data,
         bool $preserveKeys = false,
-        ?DateFormatter $dateFormatter = null
+        ?IDateFormatter $dateFormatter = null
     ): string {
         return self::_dataToQuery(
             $data,

--- a/src/Utility/Convert.php
+++ b/src/Utility/Convert.php
@@ -139,9 +139,9 @@ final class Convert
         int $mode = RecursiveIteratorIterator::LEAVES_ONLY
     ): void {
         $iterator = new RecursiveObjectOrArrayIterator($objectOrArray);
-        $iterator = new RecursiveIteratorIterator($iterator, $mode);
+        $iterator = new RecursiveIteratorIterator($inner = $iterator, $mode);
         foreach ($iterator as $key => $value) {
-            if (!$callback($value, $key, $iterator->getSubIterator())) {
+            if (!$callback($value, $key, $inner)) {
                 return;
             }
         }

--- a/tests/fixtures/Sync/Provider/JsonPlaceholderApi.php
+++ b/tests/fixtures/Sync/Provider/JsonPlaceholderApi.php
@@ -2,6 +2,7 @@
 
 namespace Lkrms\Tests\Sync\Provider;
 
+use Lkrms\Contract\IDateFormatter;
 use Lkrms\Contract\IServiceSingleton;
 use Lkrms\Curler\Contract\ICurlerHeaders;
 use Lkrms\Support\Catalog\ArrayKeyConformity;
@@ -61,7 +62,7 @@ class JsonPlaceholderApi extends HttpSyncProvider implements
         return [$this->getBaseUrl()];
     }
 
-    protected function getDateFormatter(): DateFormatter
+    protected function getDateFormatter(?string $path = null): IDateFormatter
     {
         return new DateFormatter();
     }

--- a/tests/unit/Support/Iterator/RecursiveHasChildrenCallbackIteratorTest.php
+++ b/tests/unit/Support/Iterator/RecursiveHasChildrenCallbackIteratorTest.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\Tests\Support\Iterator;
+
+use Lkrms\Support\Iterator\RecursiveHasChildrenCallbackIterator;
+use Lkrms\Support\Iterator\RecursiveObjectOrArrayIterator;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Iterator;
+use RecursiveIteratorIterator;
+use stdClass;
+
+final class RecursiveHasChildrenCallbackIteratorTest extends \Lkrms\Tests\TestCase
+{
+    public function testRecursion(): void
+    {
+        $mixed = $this->getArrayWithNestedObjectsAndArrays($a, $d1, $d2, $e);
+        $iterator = new RecursiveObjectOrArrayIterator($mixed);
+        $iterator = new RecursiveHasChildrenCallbackIterator(
+            $iterator,
+            fn($value): bool =>
+                !($value instanceof DateTimeInterface)
+        );
+        $selfFirst = new RecursiveIteratorIterator($iterator, RecursiveIteratorIterator::SELF_FIRST);
+        $leavesOnly = new RecursiveIteratorIterator($iterator, RecursiveIteratorIterator::LEAVES_ONLY);
+
+        $this->assertSame([
+            [0 => $a],
+            ['b' => ['c', ['d1' => $d1, 'd2' => $d2]]],
+            [0 => 'c'],
+            [1 => ['d1' => $d1, 'd2' => $d2]],
+            ['d1' => $d1],
+            ['d2' => $d2],
+            ['e' => $e],
+            ['f' => ['g', 'h', 'i']],
+            [0 => 'g'],
+            [1 => 'h'],
+            [2 => 'i'],
+            ['k' => 21],
+            [1 => [0, 1, 1, 2, 3, 5]],
+            [0 => 0],
+            [1 => 1],
+            [2 => 1],
+            [3 => 2],
+            [4 => 3],
+            [5 => 5],
+        ], $this->iteratorToArray($selfFirst));
+
+        $this->assertSame([
+            [0 => 'c'],
+            ['d1' => $d1],
+            ['d2' => $d2],
+            [0 => 'g'],
+            [1 => 'h'],
+            [2 => 'i'],
+            ['k' => 21],
+            [0 => 0],
+            [1 => 1],
+            [2 => 1],
+            [3 => 2],
+            [4 => 3],
+            [5 => 5],
+        ], $this->iteratorToArray($leavesOnly));
+    }
+
+    /**
+     * @return mixed[]
+     */
+    private function getArrayWithNestedObjectsAndArrays(
+        ?stdClass &$a = null,
+        ?DateTimeImmutable &$d1 = null,
+        ?DateTimeImmutable &$d2 = null,
+        ?stdClass &$e = null
+    ): array {
+        $a = new stdClass();
+        $a->b = [
+            'c',
+            [
+                'd1' => $d1 = new DateTimeImmutable(),
+                'd2' => $d2 = new DateTimeImmutable(),
+            ],
+        ];
+        $a->e = $e = new stdClass();
+        $a->e->f = ['g', 'h', 'i'];
+        $j = [
+            $a,
+            [0, 1, 1, 2, 3, 5],
+        ];
+        $a->k = 21;
+
+        return $j;
+    }
+
+    /**
+     * @param Iterator<array-key,mixed> $iterator
+     * @return array<array-key,mixed>
+     */
+    private function iteratorToArray(Iterator $iterator): array
+    {
+        foreach ($iterator as $key => $value) {
+            $out[] = [$key => $value];
+        }
+        return $out ?? [];
+    }
+}

--- a/tests/unit/Support/Iterator/RecursiveObjectOrArrayIteratorTest.php
+++ b/tests/unit/Support/Iterator/RecursiveObjectOrArrayIteratorTest.php
@@ -22,7 +22,7 @@ final class RecursiveObjectOrArrayIteratorTest extends \Lkrms\Tests\TestCase
             if ($key === 'l') {
                 /** @var RecursiveObjectOrArrayIterator $iterator */
                 $iterator = $recursiveIterator->getInnerIterator();
-                $iterator->maybeReplaceCurrentWithArray();
+                $iterator->maybeConvertToArray();
                 continue;
             }
 

--- a/tests/unit/Support/Iterator/RecursiveObjectOrArrayIteratorTest.php
+++ b/tests/unit/Support/Iterator/RecursiveObjectOrArrayIteratorTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Lkrms\Tests\Support;
+namespace Lkrms\Tests\Support\Iterator;
 
 use Lkrms\Support\Iterator\RecursiveObjectOrArrayIterator;
 use RecursiveIteratorIterator;
@@ -8,9 +8,9 @@ use stdClass;
 
 final class RecursiveObjectOrArrayIteratorTest extends \Lkrms\Tests\TestCase
 {
-    public function testArrayRecursion(): void
+    public function testRecursion(): void
     {
-        $mixed = $this->getArrayWithNestedObjectsAndArrays($a, $d1, $d2, $e);
+        $mixed = $this->getArrayWithNestedObjectsAndArrays($a, $d1, $d2, $e, $l);
         $iterator = new RecursiveObjectOrArrayIterator($mixed);
         $recursiveIterator = new RecursiveIteratorIterator($iterator, RecursiveIteratorIterator::SELF_FIRST);
         $replaceValue = ['g', 1, $d2];
@@ -18,9 +18,17 @@ final class RecursiveObjectOrArrayIteratorTest extends \Lkrms\Tests\TestCase
         $out = [];
         foreach ($recursiveIterator as $key => $value) {
             $out[] = [$key => $value];
+
+            if ($key === 'l') {
+                /** @var RecursiveObjectOrArrayIterator $iterator */
+                $iterator = $recursiveIterator->getInnerIterator();
+                $iterator->maybeReplaceCurrentWithArray();
+                continue;
+            }
+
             if (($replaceKey = array_search($value, $replaceValue, true)) !== false) {
                 /** @var RecursiveObjectOrArrayIterator $iterator */
-                $iterator = $recursiveIterator->getSubIterator();
+                $iterator = $recursiveIterator->getInnerIterator();
                 $iterator->replace($replaceWith[$replaceKey]);
             }
         }
@@ -41,6 +49,8 @@ final class RecursiveObjectOrArrayIteratorTest extends \Lkrms\Tests\TestCase
             [0 => 'g'],
             [1 => 'h'],
             [2 => 'i'],
+            ['l' => $l],
+            ['m' => 'tree'],
             ['k' => 21],
             [1 => [0, 1, 1, 2, 3, 5]],
             [0 => 0],
@@ -67,13 +77,19 @@ final class RecursiveObjectOrArrayIteratorTest extends \Lkrms\Tests\TestCase
         $this->assertSame($e, $mixed[0]->e);
         $this->assertSame([100, 'h', 'i'], $mixed[0]->e->f);
         $this->assertSame(21, $mixed[0]->k);
+        $this->assertSame(['m' => 'tree'], $mixed[0]->e->l);
     }
 
     /**
      * @return mixed[]
      */
-    private function getArrayWithNestedObjectsAndArrays(?stdClass &$a = null, ?stdClass &$d1 = null, ?stdClass &$d2 = null, ?stdClass &$e = null): array
-    {
+    private function getArrayWithNestedObjectsAndArrays(
+        ?stdClass &$a = null,
+        ?stdClass &$d1 = null,
+        ?stdClass &$d2 = null,
+        ?stdClass &$e = null,
+        ?stdClass &$l = null
+    ): array {
         $a = new stdClass();
         $a->b = [
             'c',
@@ -89,6 +105,8 @@ final class RecursiveObjectOrArrayIteratorTest extends \Lkrms\Tests\TestCase
             [0, 1, 1, 2, 3, 5],
         ];
         $a->k = 21;
+        $e->l = $l = new stdClass();
+        $e->l->m = 'tree';
 
         return $j;
     }


### PR DESCRIPTION
- Fix issue where `RecursiveHasChildrenCallbackIterator` is only
  effective on children of the root node
  - This issue caused `Curler` to fail to serialize `CurlerFile` and
    `DateTimeInterface` instances in request data
- Fix inconsistent return type of
  `RecursiveObjectOrArrayIterator::maybeReplaceCurrentWithArray()`
- Add `RecursiveHasChildrenCallbackIteratorTest`, update
  `RecursiveObjectOrArrayIteratorTest`