### PR TITLE
Sync: improve serialization, build out tests

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,7 +10,6 @@ parameters:
 		- scripts
 		- src
 		- stubs
-		- tests/fixtures/Console
 		- tests/unit
 		- bootstrap.php
 	ignoreErrors:

--- a/src/Concern/TExtensible.php
+++ b/src/Concern/TExtensible.php
@@ -16,19 +16,19 @@ trait TExtensible
      *
      * @var array<string,mixed>
      */
-    private $_MetaProperties = [];
+    private $MetaProperties = [];
 
     /**
      * Normalised property name => first name passed to setMetaProperty
      *
      * @var array<string,string>
      */
-    private $_MetaPropertyNames = [];
+    private $MetaPropertyNames = [];
 
     final public function clearMetaProperties()
     {
-        $this->_MetaProperties = [];
-        $this->_MetaPropertyNames = [];
+        $this->MetaProperties = [];
+        $this->MetaPropertyNames = [];
 
         return $this;
     }
@@ -39,9 +39,9 @@ trait TExtensible
     final public function setMetaProperty(string $name, $value): void
     {
         $normalised = IS::get(static::class)->maybeNormalise($name);
-        $this->_MetaProperties[$normalised] = $value;
-        if (!array_key_exists($normalised, $this->_MetaPropertyNames)) {
-            $this->_MetaPropertyNames[$normalised] = $name;
+        $this->MetaProperties[$normalised] = $value;
+        if (!array_key_exists($normalised, $this->MetaPropertyNames)) {
+            $this->MetaPropertyNames[$normalised] = $name;
         }
     }
 
@@ -50,27 +50,27 @@ trait TExtensible
      */
     final public function getMetaProperty(string $name)
     {
-        return $this->_MetaProperties[IS::get(static::class)->maybeNormalise($name)] ?? null;
+        return $this->MetaProperties[IS::get(static::class)->maybeNormalise($name)] ?? null;
     }
 
     final public function isMetaPropertySet(string $name): bool
     {
-        return isset($this->_MetaProperties[IS::get(static::class)->maybeNormalise($name)]);
+        return isset($this->MetaProperties[IS::get(static::class)->maybeNormalise($name)]);
     }
 
     final public function unsetMetaProperty(string $name): void
     {
-        unset($this->_MetaProperties[IS::get(static::class)->maybeNormalise($name)]);
+        unset($this->MetaProperties[IS::get(static::class)->maybeNormalise($name)]);
     }
 
     final public function getMetaProperties(): array
     {
         return array_combine(
             array_map(
-                fn(string $name): string => $this->_MetaPropertyNames[$name],
-                array_keys($this->_MetaProperties)
+                fn(string $name): string => $this->MetaPropertyNames[$name],
+                array_keys($this->MetaProperties)
             ),
-            $this->_MetaProperties
+            $this->MetaProperties
         );
     }
 }

--- a/src/Console/ConsoleWriter.php
+++ b/src/Console/ConsoleWriter.php
@@ -279,6 +279,25 @@ final class ConsoleWriter implements ReceivesFacade
             $this->StdoutTarget = null;
         }
 
+        // Reinstate previous STDOUT and STDERR targets if possible
+        if ($this->Targets &&
+                (!$this->StdoutTarget || !$this->StderrTarget)) {
+            foreach (array_reverse($this->Targets) as $target) {
+                if (!$this->StdoutTarget && $target->isStdout()) {
+                    $this->StdoutTarget = $target;
+                    if ($this->StderrTarget) {
+                        break;
+                    }
+                }
+                if (!$this->StderrTarget && $target->isStderr()) {
+                    $this->StderrTarget = $target;
+                    if ($this->StdoutTarget) {
+                        break;
+                    }
+                }
+            }
+        }
+
         return $this;
     }
 

--- a/src/Console/Target/MockTarget.php
+++ b/src/Console/Target/MockTarget.php
@@ -1,30 +1,35 @@
 <?php declare(strict_types=1);
 
-namespace Lkrms\Tests\Console;
+namespace Lkrms\Console\Target;
 
 use Lkrms\Console\Catalog\ConsoleLevel as Level;
 use Lkrms\Console\Contract\IConsoleTarget;
 use Lkrms\Console\ConsoleFormatter;
 
-class MockTarget implements IConsoleTarget
+/**
+ * Test console output
+ */
+final class MockTarget implements IConsoleTarget
 {
-    protected bool $IsStdout;
+    private bool $IsStdout;
 
-    protected bool $IsStderr;
+    private bool $IsStderr;
 
-    protected bool $IsTty;
+    private bool $IsTty;
+
+    private int $Width;
 
     /**
      * @var resource|null
      */
-    protected $Stream;
+    private $Stream;
 
-    protected ConsoleFormatter $Formatter;
+    private ConsoleFormatter $Formatter;
 
     /**
      * @var array<array{Level::*,string}>
      */
-    protected array $Messages = [];
+    private array $Messages = [];
 
     /**
      * @param resource|null $stream If provided, console messages are also
@@ -34,12 +39,14 @@ class MockTarget implements IConsoleTarget
         bool $isStdout = true,
         bool $isStderr = true,
         bool $isTty = true,
+        int $width = 80,
         $stream = null,
         ?ConsoleFormatter $formatter = null
     ) {
         $this->IsStdout = $isStdout;
         $this->IsStderr = $isStderr;
         $this->IsTty = $isTty;
+        $this->Width = $width;
         $this->Stream = $stream;
         $this->Formatter = $formatter
             ?: new ConsoleFormatter(null, null, fn() => $this->width());
@@ -71,7 +78,7 @@ class MockTarget implements IConsoleTarget
 
     public function width(): ?int
     {
-        return 80;
+        return $this->Width;
     }
 
     public function write($level, string $message, array $context = []): void

--- a/src/Facade/Sync.php
+++ b/src/Facade/Sync.php
@@ -33,6 +33,8 @@ use Lkrms\Sync\Support\SyncStore;
  * @method static SyncErrorCollection getErrors() Get sync operation errors recorded so far
  * @method static string|null getFilename() Get the filename of the database
  * @method static class-string<ISyncClassResolver>|null getNamespaceResolver(class-string<ISyncEntity|ISyncProvider> $class) Get the class resolver for an entity or provider's namespace
+ * @method static ISyncProvider|null getProvider(string $hash) Get a registered sync provider
+ * @method static string getProviderHash(ISyncProvider $provider) Get the stable identifier of a sync provider
  * @method static int getProviderId(ISyncProvider $provider) Get the provider ID of a registered sync provider, starting a run if necessary
  * @method static int getRunId() Get the run ID of the current run
  * @method static string getRunUuid(bool $binary = false) Get the UUID of the current run (see {@see SyncStore::getRunUuid()})

--- a/src/Support/IntrospectionClass.php
+++ b/src/Support/IntrospectionClass.php
@@ -194,6 +194,13 @@ class IntrospectionClass
     public $ParameterIndex = [];
 
     /**
+     * Declared and "magic" properties that are both readable and writable
+     *
+     * @var string[]
+     */
+    public $SerializableProperties = [];
+
+    /**
      * Normalised properties (declared and "magic" property names)
      *
      * @var string[]
@@ -484,6 +491,24 @@ class IntrospectionClass
                 + ($this->Actions[self::ACTION_SET] ?? [])
                 + ($this->Actions[self::ACTION_UNSET] ?? [])
         );
+
+        // Create a combined list of declared property and normalised method
+        // names that are both readable and writable
+        $this->SerializableProperties =
+            array_merge(
+                array_values(
+                    array_intersect(
+                        ($this->ReadableProperties ?: $this->PublicProperties),
+                        ($this->WritableProperties ?: $this->PublicProperties),
+                    )
+                ),
+                array_keys(
+                    array_intersect_key(
+                        ($this->Actions[self::ACTION_GET] ?? []),
+                        ($this->Actions[self::ACTION_SET] ?? []),
+                    )
+                )
+            );
 
         if ($this->IsRelatable) {
             /** @var array<string,array<RelationshipType::*,class-string<IRelatable>>> */

--- a/src/Support/Introspector.php
+++ b/src/Support/Introspector.php
@@ -44,6 +44,7 @@ use UnexpectedValueException;
  * @property-read array<string,string> $DateParameters Parameters with a declared type that implements DateTimeInterface (normalised name => declared name)
  * @property-read mixed[] $DefaultArguments Default values for (all) constructor parameters
  * @property-read array<string,int> $ParameterIndex Constructor parameter name => index
+ * @property-read string[] $SerializableProperties Declared and "magic" properties that are both readable and writable
  * @property-read string[] $NormalisedKeys Normalised properties (declared and "magic" property names)
  * @property-read string|null $ParentProperty The normalised parent property
  * @property-read string|null $ChildrenProperty The normalised children property

--- a/tests/unit/Sync/Command/CheckSyncProviderHeartbeatTest.php
+++ b/tests/unit/Sync/Command/CheckSyncProviderHeartbeatTest.php
@@ -2,6 +2,7 @@
 
 namespace Lkrms\Tests\Sync\Command;
 
+use Lkrms\Cli\Contract\ICliCommand;
 use Lkrms\Cli\CliApplication;
 use Lkrms\Sync\Command\CheckSyncProviderHeartbeat;
 use Lkrms\Tests\Sync\Provider\JsonPlaceholderApi;
@@ -11,22 +12,56 @@ class CheckSyncProviderHeartbeatTest extends \Lkrms\Tests\CommandTestCase
     protected function startApp(CliApplication $app): CliApplication
     {
         return $app
+            ->startCache()
             ->startSync(__METHOD__, [])
             ->service(JsonPlaceholderApi::class);
+    }
+
+    protected function makeCommandAssertions(
+        CliApplication $app,
+        ICliCommand $command,
+        ...$args
+    ): void {
+        $httpRequestCount = $args[6] ?? null;
+
+        if ($httpRequestCount === null) {
+            return;
+        }
+
+        $provider = $app->get(JsonPlaceholderApi::class);
+        $this->assertSame(
+            $httpRequestCount,
+            $provider->HttpRequestCount,
+            'JsonPlaceholderApi::$HttpRequestCount',
+        );
     }
 
     /**
      * @dataProvider runProvider
      *
      * @param string[] $args
+     * @param array<string,int>|null $httpRequestCount
      */
-    public function testRun(string $output, int $exitStatus, array $args): void
-    {
-        $this->assertCommandProduces($output, $exitStatus, CheckSyncProviderHeartbeat::class, $args);
+    public function testRun(
+        string $output,
+        int $exitStatus,
+        array $args,
+        ?array $httpRequestCount = null,
+        int $runs = 1
+    ): void {
+        $this->assertCommandProduces(
+            $output,
+            $exitStatus,
+            CheckSyncProviderHeartbeat::class,
+            $args,
+            null,
+            $runs,
+            $httpRequestCount,
+        );
     }
 
     /**
-     * @return array<array{string,int,string[]}>
+     * @return array<array{string,int,string[],3?:array<string,int>|null,4?:int}>
      */
     public static function runProvider(): array
     {
@@ -37,12 +72,23 @@ class CheckSyncProviderHeartbeatTest extends \Lkrms\Tests\CommandTestCase
                 <<<EOF
                 ==> Sending heartbeat request to 1 provider
                  -> Checking JSONPlaceholder { http://localhost:3001 } [#1]{$cr}
-                 -> Heartbeat check not supported: JSONPlaceholder { http://localhost:3001 } [#1]
+                ==> Connected to JSONPlaceholder { http://localhost:3001 } as Leanne Graham
+                 -> Heartbeat OK: JSONPlaceholder { http://localhost:3001 } [#1]
+                 // 1 provider checked without errors
+                ==> Sending heartbeat request to 1 provider
+                 -> Checking JSONPlaceholder { http://localhost:3001 } [#1]{$cr}
+                ==> Connected to JSONPlaceholder { http://localhost:3001 } as Leanne Graham
+                 -> Heartbeat OK: JSONPlaceholder { http://localhost:3001 } [#1]
                  // 1 provider checked without errors
 
                 EOF,
                 0,
-                []
+                [],
+                [
+                    'http://localhost:3001/users/1' => 1,
+                    'http://localhost:3001/users/1/posts' => 1,
+                ],
+                2,
             ],
         ];
     }


### PR DESCRIPTION
- Allow `SyncEntity` objects to be serialized, e.g. for caching
  - Surface declared and "magic" property names that are both readable and writable via `Introspector::$SerializableProperties`
  - Add `SyncStore::getProviderHash()` and `getProvider()` so sync providers can be serialized by hash
  - Add `SyncEntity::__serialize()` and `__unserialize()`

- Move `MockTarget` from `Lkrms\Tests\Console` to `Lkrms\Console\Target`
- Build out `CommandTestCase` with support for custom assertions and multiple runs per command
- Add `checkHeartbeat()` implementation to `JsonPlaceholderApi`
- Build out `CheckSyncProviderHeartbeatTest`

Also:
- In `ConsoleWriter`, reinstate previous STDOUT/STDERR targets after deregistering a target if possible