### PR TITLE
Sync: allow context objects to be passed to entity resolvers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Start Mockoon CLI
         shell: bash
-        run: scripts/start-mockoon.sh tests/fixtures/.mockoon/JsonPlaceholderApi.json 3001
+        run: scripts/start-mockoon.sh
 
       - name: Run PHPUnit tests and generate code coverage report
         run: vendor/bin/phpunit --no-coverage --coverage-clover=coverage.xml

--- a/scripts/start-mockoon.sh
+++ b/scripts/start-mockoon.sh
@@ -12,6 +12,8 @@ function die() {
 [[ ${BASH_SOURCE[0]} -ef scripts/start-mockoon.sh ]] ||
     die "must run from root of package folder"
 
+(($#)) || set -- tests/fixtures/.mockoon/JsonPlaceholderApi.json 3001
+
 seconds=${3-60}
 [[ -r ${1-} ]] && [[ ${2-} =~ ^[1-9][0-9]+$ ]] && [[ $seconds =~ ^[0-9]+$ ]] ||
     die "usage: ${0##*/} <data_file> <port> [<seconds>]"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -38,6 +38,6 @@ run scripts/generate.php --check
 run vendor/bin/pretty-php --diff
 run_with_php_versions 82 74 vendor/bin/phpstan
 run scripts/stop-mockoon.sh || (($? == 1)) || die 'error stopping mockoon'
-run scripts/start-mockoon.sh tests/fixtures/.mockoon/JsonPlaceholderApi.json 3001 >/dev/null
+run scripts/start-mockoon.sh >/dev/null
 trap 'run scripts/stop-mockoon.sh' EXIT
 run_with_php_versions 82 81 80 74 vendor/bin/phpunit

--- a/src/Sync/Concept/SyncEntity.php
+++ b/src/Sync/Concept/SyncEntity.php
@@ -726,14 +726,22 @@ abstract class SyncEntity extends Entity implements ISyncEntity, ReturnsNormalis
      */
     final public static function idFromNameOrId(
         $nameOrId,
-        ISyncProvider $provider,
-        ?float $uncertaintyThreshold = 0.5,
+        $providerOrContext,
+        ?float $uncertaintyThreshold = null,
         ?string $nameProperty = null,
         ?float &$uncertainty = null
     ) {
         if ($nameOrId === null) {
             $uncertainty = null;
             return null;
+        }
+
+        if ($providerOrContext instanceof ISyncProvider) {
+            $provider = $providerOrContext;
+            $context = $provider->container();
+        } else {
+            $context = $providerOrContext;
+            $provider = $context->provider();
         }
 
         if ($provider->isValidIdentifier($nameOrId, static::class)) {
@@ -743,7 +751,7 @@ abstract class SyncEntity extends Entity implements ISyncEntity, ReturnsNormalis
 
         $entity =
             $provider
-                ->with(static::class)
+                ->with(static::class, $context)
                 ->getResolver(
                     $nameProperty,
                     Algorithm::SAME | Algorithm::CONTAINS | Algorithm::NGRAM_SIMILARITY | Flag::NORMALISE,

--- a/src/Sync/Contract/ISyncContext.php
+++ b/src/Sync/Contract/ISyncContext.php
@@ -129,12 +129,16 @@ interface ISyncContext extends IProviderContext
      * Get a value from the filter most recently passed via optional sync
      * operation arguments
      *
+     * If `$orValue` is `true` and a value for `$key` has been applied to the
+     * context via {@see IProviderContext::withValue()}, it is returned if there
+     * is no matching filter.
+     *
      * @return mixed `null` if the value has been claimed via
      * {@see ISyncContext::claimFilter()} or wasn't passed to the operation.
      *
      * @see ISyncContext::withArgs()
      */
-    public function getFilter(string $key);
+    public function getFilter(string $key, bool $orValue = true);
 
     /**
      * Get a value from the filter most recently passed via optional sync
@@ -144,12 +148,16 @@ interface ISyncContext extends IProviderContext
      * {@see ISyncContext::claimFilter()} modifies the object it is called on
      * instead of returning a modified clone.
      *
+     * If `$orValue` is `true` and a value for `$key` has been applied to the
+     * context via {@see IProviderContext::withValue()}, it is returned if there
+     * is no matching filter.
+     *
      * @return mixed `null` if the value has already been claimed or wasn't
      * passed to the operation.
      *
      * @see ISyncContext::withArgs()
      */
-    public function claimFilter(string $key);
+    public function claimFilter(string $key, bool $orValue = true);
 
     /**
      * Get the deferred sync entity policy applied to the context

--- a/src/Sync/Contract/ISyncEntity.php
+++ b/src/Sync/Contract/ISyncEntity.php
@@ -78,12 +78,13 @@ interface ISyncEntity extends
      * - there are multiple matching entities
      *
      * @param int|string|null $nameOrId
+     * @param ISyncProvider|ISyncContext $providerOrContext
      * @return int|string|null
      */
     public static function idFromNameOrId(
         $nameOrId,
-        ISyncProvider $provider,
-        ?float $uncertaintyThreshold = 0.5,
+        $providerOrContext,
+        ?float $uncertaintyThreshold = null,
         ?string $nameProperty = null,
         ?float &$uncertainty = null
     );

--- a/src/Sync/Support/SyncContext.php
+++ b/src/Sync/Support/SyncContext.php
@@ -143,17 +143,17 @@ final class SyncContext extends ProviderContext implements ISyncContext
     /**
      * @inheritDoc
      */
-    public function getFilter(string $key)
+    public function getFilter(string $key, bool $orValue = true)
     {
-        return $this->doGetFilter($key);
+        return $this->doGetFilter($key, $orValue);
     }
 
     /**
      * @inheritDoc
      */
-    public function claimFilter(string $key)
+    public function claimFilter(string $key, bool $orValue = true)
     {
-        return $this->doGetFilter($key, true);
+        return $this->doGetFilter($key, $orValue, true);
     }
 
     /**
@@ -200,13 +200,13 @@ final class SyncContext extends ProviderContext implements ISyncContext
     /**
      * @return mixed
      */
-    private function doGetFilter(string $key, bool $claim = false)
+    private function doGetFilter(string $key, bool $orValue, bool $claim = false)
     {
         if (!array_key_exists($key, $this->Filters)) {
             $key = Convert::toSnakeCase($key);
             if (!array_key_exists($key, $this->Filters)) {
                 if (substr($key, -3) !== '_id') {
-                    return null;
+                    return $orValue ? $this->getValue($key) : null;
                 }
                 $name = Convert::toSnakeCase(substr($key, 0, -3));
                 if (array_key_exists($name, $this->FilterKeys)) {
@@ -217,7 +217,7 @@ final class SyncContext extends ProviderContext implements ISyncContext
                 } elseif (array_key_exists($name, $this->Filters)) {
                     $key = $name;
                 } else {
-                    return null;
+                    return $orValue ? $this->getValue($key) : null;
                 }
             }
         }

--- a/src/Sync/Support/SyncEntityFuzzyResolver.php
+++ b/src/Sync/Support/SyncEntityFuzzyResolver.php
@@ -244,19 +244,15 @@ final class SyncEntityFuzzyResolver implements ISyncEntityResolver
     {
         $this->Entities = [];
         foreach ($this->EntityProvider->getList() as $entity) {
+            $name =
+                is_string($this->NameProperty)
+                    ? $entity->{$this->NameProperty}
+                    : ($this->NameProperty)($entity);
             $this->Entities[] = [
                 $entity,
                 $this->Algorithm & Flag::NORMALISE
-                    ? Convert::toNormal(
-                        is_string($this->NameProperty)
-                            ? $entity->{$this->NameProperty}
-                            : ($this->NameProperty)($entity)
-                    )
-                    : (
-                        is_string($this->NameProperty)
-                            ? $entity->{$this->NameProperty}
-                            : ($this->NameProperty)($entity)
-                    ),
+                    ? Convert::toNormal($name)
+                    : $name,
                 $this->WeightProperty === null
                     ? 0
                     : $entity->{$this->WeightProperty},

--- a/tests/unit/Sync/Concept/SyncEntityTest.php
+++ b/tests/unit/Sync/Concept/SyncEntityTest.php
@@ -39,7 +39,7 @@ final class SyncEntityTest extends \Lkrms\Tests\Sync\SyncTestCase
         ?float $expectedUncertainty,
         $nameOrId,
         string $entity,
-        ?float $uncertaintyThreshold = 0.5,
+        ?float $uncertaintyThreshold = null,
         ?string $nameProperty = null
     ): void {
         if ($expected === false) {


### PR DESCRIPTION
- Allow filters and context values to be applied to `READ_LIST` operations performed by entity resolvers
- Optionally return context values from `ISyncContext::getFilter()` and `claimFilter()` if there is no matching filter (enabled by default)
- Use `null` as the default uncertainty threshold

Also:
- Simplify Mockoon startup