### PR TITLE
Fix Curler issues

### DIFF
--- a/stubs/CurlHandle.php
+++ b/stubs/CurlHandle.php
@@ -1,0 +1,5 @@
+<?php
+
+if (PHP_VERSION_ID < 80000 && extension_loaded('curl')) {
+    final class CurlHandle {}
+}

--- a/tests/phpstan-conditional.php
+++ b/tests/phpstan-conditional.php
@@ -9,13 +9,7 @@ if (PHP_VERSION_ID < 80000) {
                     'tests/fixtures/Utility/Reflect/MyClassWithUnionsAndIntersections.php',
                 ],
             ],
-            'ignoreErrors' => [
-                [
-                    'message' => '#^Property Lkrms\\\\Curler\\\\Curler\:\:\$Handle has unknown class CurlHandle as its type\.$#',
-                    'count' => 1,
-                    'path' => '../src/Curler/Curler.php',
-                ],
-            ],
+            'ignoreErrors' => [],
         ]
     ];
 }


### PR DESCRIPTION
- Create a separate cURL handle for each request that returns paginated data via a generator to resolve errors arising from multiple `Curler` instances sharing one handle
- Add a stub for `CurlHandle` to resolve PHPStan error