### PR TITLE
Sync: fix issue where empty child relationships do not always resolve

### DIFF
--- a/src/Sync/Support/SyncIntrospector.php
+++ b/src/Sync/Support/SyncIntrospector.php
@@ -867,7 +867,11 @@ final class SyncIntrospector extends Introspector
                     $data[$idKey],
                     $filter,
                     $replace,
-                    static function ($entities) use ($entity): void {
+                    static function ($entities) use ($entity, $property): void {
+                        if (!$entities) {
+                            $entity->{$property} = [];
+                            return;
+                        }
                         foreach ($entities as $child) {
                             /** @var ISyncEntity&ITreeable $child */
                             $entity->addChild($child);


### PR DESCRIPTION
- If a child relationship resolves to an empty list, assign it directly to the children property because `addChild()` will not be called