### PR TITLE
Finalise `CacheStore` refactoring

### DIFF
--- a/src/Facade/Cache.php
+++ b/src/Facade/Cache.php
@@ -20,7 +20,10 @@ use DateTimeInterface;
  * @method static CacheStore deleteAll() Delete all items
  * @method static CacheStore flush() Delete expired items
  * @method static mixed|false get(string $key, ?int $maxAge = null) Retrieve an item stored under a given key (see {@see CacheStore::get()})
+ * @method static string[] getAllKeys(?int $maxAge = null) Get a list of keys under which unexpired items are stored (see {@see CacheStore::getAllKeys()})
  * @method static string|null getFilename() Get the filename of the database
+ * @method static mixed|false getInstanceOf(string $key, class-string $class, ?int $maxAge = null) Retrieve an instance of a class stored under a given key (see {@see CacheStore::getInstanceOf()})
+ * @method static int getItemCount(?int $maxAge = null) Get the number of unexpired items in the store (see {@see CacheStore::getItemCount()})
  * @method static bool has(string $key, ?int $maxAge = null) True if an item exists and has not expired (see {@see CacheStore::has()})
  * @method static bool isOpen() Check if a database is open
  * @method static mixed maybeGet(string $key, callable(): mixed $callback, DateTimeInterface|int|null $expires = null) Retrieve an item stored under a given key, or get it from a callback and store it for subsequent retrieval (see {@see CacheStore::maybeGet()})

--- a/src/Utility/Assert.php
+++ b/src/Utility/Assert.php
@@ -73,6 +73,19 @@ final class Assert
         }
     }
 
+    /**
+     * Assert that a value is an instance of a class or interface
+     *
+     * @param mixed $value
+     * @param class-string $class
+     */
+    public static function instanceOf($value, string $class, ?string $name = null): void
+    {
+        if (!is_a($value, $class)) {
+            self::throwException(sprintf('{} must be an instance of %s', $class), $name);
+        }
+    }
+
     public static function patternMatches(?string $value, string $pattern, ?string $name = null): void
     {
         if (is_null($value) || !preg_match($pattern, $value)) {


### PR DESCRIPTION
- Add `Cache::getInstanceOf()`
- Add generics
- Honour the `asOfNow()` timestamp when flushing expired items
- Add `Cache::getItemCount()` and `Cache::getAllKeys()`

Also:
- Add `Assert::instanceOf()`