### PR TITLE
Fix `HttpHeaders` regressions and restore missing functionality

### DIFF
--- a/src/Http/Auth/AccessToken.php
+++ b/src/Http/Auth/AccessToken.php
@@ -6,6 +6,7 @@ use Lkrms\Concern\TFullyReadable;
 use Lkrms\Contract\IImmutable;
 use Lkrms\Contract\IReadable;
 use Lkrms\Exception\InvalidArgumentException;
+use Lkrms\Http\Contract\IAccessToken;
 use Lkrms\Utility\Date;
 use DateTimeImmutable;
 use DateTimeInterface;
@@ -19,34 +20,25 @@ use DateTimeInterface;
  * @property-read string[] $Scopes
  * @property-read array<string,mixed> $Claims
  */
-final class AccessToken implements IReadable, IImmutable
+final class AccessToken implements IAccessToken, IImmutable, IReadable
 {
     use TFullyReadable;
 
-    /**
-     * @var string
-     */
-    protected $Token;
+    protected string $Token;
 
-    /**
-     * @var string
-     */
-    protected $Type;
+    protected string $Type;
 
-    /**
-     * @var DateTimeImmutable|null
-     */
-    protected $Expires;
+    protected ?DateTimeImmutable $Expires;
 
     /**
      * @var string[]
      */
-    protected $Scopes;
+    protected array $Scopes;
 
     /**
      * @var array<string,mixed>
      */
-    protected $Claims;
+    protected array $Claims;
 
     /**
      * Creates a new AccessToken object
@@ -57,8 +49,13 @@ final class AccessToken implements IReadable, IImmutable
      * @param string[]|null $scopes
      * @param array<string,mixed>|null $claims
      */
-    public function __construct(string $token, string $type, $expires, ?array $scopes = null, ?array $claims = null)
-    {
+    public function __construct(
+        string $token,
+        string $type,
+        $expires,
+        ?array $scopes = null,
+        ?array $claims = null
+    ) {
         if (is_int($expires) && $expires < 0) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid $expires: %d',
@@ -75,5 +72,21 @@ final class AccessToken implements IReadable, IImmutable
                 : new DateTimeImmutable("@$expires"));
         $this->Scopes = $scopes ?: [];
         $this->Claims = $claims ?: [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getToken(): string
+    {
+        return $this->Token;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getType(): string
+    {
+        return $this->Type;
     }
 }

--- a/src/Http/Contract/IAccessToken.php
+++ b/src/Http/Contract/IAccessToken.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\Http\Contract;
+
+interface IAccessToken
+{
+    /**
+     * Get the object's token string
+     */
+    public function getToken(): string;
+
+    /**
+     * Get the token's type, e.g. "Bearer"
+     */
+    public function getType(): string;
+}

--- a/src/Http/Contract/IHttpHeaders.php
+++ b/src/Http/Contract/IHttpHeaders.php
@@ -5,6 +5,7 @@ namespace Lkrms\Http\Contract;
 use Lkrms\Contract\Arrayable;
 use Lkrms\Contract\ICollection;
 use Lkrms\Contract\IImmutable;
+use Lkrms\Http\Catalog\HttpHeader;
 
 /**
  * A collection of HTTP headers
@@ -51,12 +52,22 @@ interface IHttpHeaders extends ICollection, IImmutable
     public function unset($key);
 
     /**
-     * Apply values to headers from an array or Traversable, optionally
-     * preserving existing values
+     * Merge the collection with the given headers, optionally preserving
+     * existing values
      *
      * @param Arrayable<string,string[]|string>|iterable<string,string[]|string> $items
      */
     public function merge($items, bool $preserveExisting = false);
+
+    /**
+     * Apply an access token to the collection
+     *
+     * @return static
+     */
+    public function authorize(
+        IAccessToken $token,
+        string $headerName = HttpHeader::AUTHORIZATION
+    );
 
     /**
      * Reduce the collection to headers received after the HTTP message body


### PR DESCRIPTION
- Add `IAccessToken` and implement its methods in `AccessToken`
- Add `IHttpHeaders::authorize()`, reinstating previous `applyAccessToken()` grammar
- Fix issue where `HttpHeaders::filter()` doesn't operate on lowercase keys when `CALLBACK_USE_KEY` or `CALLBACK_USE_BOTH` are in use