### PR TITLE
Build out filesystem function wrappers for upcoming `HttpStream` class

### DIFF
--- a/src/Concern/TCollection.php
+++ b/src/Concern/TCollection.php
@@ -205,8 +205,11 @@ trait TCollection
      */
     protected function getItems($items): array
     {
-        if ($items instanceof static) {
+        if ($items instanceof self) {
             return $items->Items;
+        }
+        if ($items instanceof Arrayable) {
+            return $items->toArray();
         }
         if (is_array($items)) {
             return $items;

--- a/src/Container/Application.php
+++ b/src/Container/Application.php
@@ -637,7 +637,7 @@ class Application extends Container implements IApplication
             $report[] = implode("\n", $lines);
         }
 
-        if ($report ?? null) {
+        if (isset($report)) {
             Console::print("\n" . implode("\n\n", $report), $level);
         }
     }

--- a/src/Curler/Curler.php
+++ b/src/Curler/Curler.php
@@ -1028,7 +1028,7 @@ final class Curler implements IReadable, IWritable, ProvidesBuilder
             $this->close();
         }
 
-        if ($cacheKey ?? null) {
+        if (isset($cacheKey)) {
             Cache::set(
                 $cacheKey,
                 [$this->StatusCode, $this->ReasonPhrase, $this->ResponseHeaders, $this->ResponseBody],
@@ -1246,7 +1246,7 @@ final class Curler implements IReadable, IWritable, ProvidesBuilder
         if ($this->responseContentTypeIs(MimeType::JSON)) {
             $response = json_decode($this->ResponseBody, $this->ObjectAsArray);
 
-            if ($pager ?? null) {
+            if (isset($pager)) {
                 $response = $pager->getPage($response, $this)->entities();
                 if (array_keys($response) === [0] &&
                         (is_array($response[0]) || is_scalar($response[0]))) {

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -6,9 +6,9 @@ use Lkrms\Exception\Concern\ExceptionTrait;
 use Lkrms\Exception\Contract\ExceptionInterface;
 
 /**
- * Base class for exceptions
+ * Base class for runtime exceptions
  */
-class Exception extends \Exception implements ExceptionInterface
+abstract class Exception extends \RuntimeException implements ExceptionInterface
 {
     use ExceptionTrait;
 }

--- a/src/Exception/MethodNotImplementedException.php
+++ b/src/Exception/MethodNotImplementedException.php
@@ -2,14 +2,18 @@
 
 namespace Lkrms\Exception;
 
+use Lkrms\Exception\Concern\ExceptionTrait;
+use Lkrms\Exception\Contract\ExceptionInterface;
 use Lkrms\Utility\Reflect;
-use ReflectionClass;
+use ReflectionMethod;
 
 /**
  * Thrown when an unimplemented method is called
  */
-class MethodNotImplementedException extends \Lkrms\Exception\Exception
+class MethodNotImplementedException extends \BadMethodCallException implements ExceptionInterface
 {
+    use ExceptionTrait;
+
     /**
      * @var class-string
      */
@@ -31,9 +35,10 @@ class MethodNotImplementedException extends \Lkrms\Exception\Exception
      */
     public function __construct(string $class, string $method, ?string $prototypeClass = null)
     {
-        if (!$prototypeClass &&
-                ($_class = new ReflectionClass($class))->hasMethod($method)) {
-            $prototypeClass = Reflect::getMethodPrototypeClass($_class->getMethod($method))->getName();
+        if ($prototypeClass === null) {
+            $prototypeClass = Reflect::getMethodPrototypeClass(
+                new ReflectionMethod($class, $method)
+            )->getName();
         }
 
         $this->Class = $class;
@@ -41,10 +46,10 @@ class MethodNotImplementedException extends \Lkrms\Exception\Exception
         $this->PrototypeClass = $prototypeClass;
 
         parent::__construct(sprintf(
-            '%s has not implemented %s::%s()',
+            '%s does not implement %s::%s()',
             $class,
             $prototypeClass,
-            $method
+            $method,
         ));
     }
 

--- a/src/Http/HttpHeaders.php
+++ b/src/Http/HttpHeaders.php
@@ -5,6 +5,7 @@ namespace Lkrms\Http;
 use Lkrms\Concern\Immutable;
 use Lkrms\Concern\ImmutableArrayAccess;
 use Lkrms\Concern\TReadableCollection;
+use Lkrms\Contract\Arrayable;
 use Lkrms\Contract\ICollection;
 use Lkrms\Exception\InvalidArgumentException;
 use Lkrms\Http\Catalog\HttpHeader;
@@ -201,10 +202,10 @@ class HttpHeaders implements IHttpHeaders
      */
     public function merge($items, bool $preserveExisting = false)
     {
-        $normalise = true;
         if ($items instanceof self) {
             $items = $items->headers();
-            $normalise = false;
+        } elseif ($items instanceof Arrayable) {
+            $items = $items->toArray();
         }
 
         $headers = $this->Headers;
@@ -231,12 +232,10 @@ class HttpHeaders implements IHttpHeaders
                 // Maintain the order of $index for comparison
                 $index[$lower] = [];
             }
-            if ($normalise) {
-                $key = $this->normaliseName($key);
-            }
+            $key = $this->normaliseName($key);
             foreach ($values as $value) {
                 $applied = true;
-                $headers[] = [$key => $normalise ? $this->normaliseValue($value) : $value];
+                $headers[] = [$key => $this->normaliseValue($value)];
                 $index[$lower][] = array_key_last($headers);
             }
         }

--- a/src/Http/HttpRequest.php
+++ b/src/Http/HttpRequest.php
@@ -7,7 +7,7 @@ use Lkrms\Contract\IReadable;
 use Lkrms\Http\Contract\IHttpHeaders;
 
 /**
- * Represents an incoming HTTP request
+ * Represents an HTTP request
  *
  * @property-read string $Method
  * @property-read string $Target

--- a/src/Http/HttpResponse.php
+++ b/src/Http/HttpResponse.php
@@ -8,7 +8,7 @@ use Lkrms\Http\Contract\IHttpHeaders;
 use Lkrms\Utility\Arr;
 
 /**
- * Represents an outgoing HTTP response
+ * Represents an HTTP response
  *
  * @property-read string $ProtocolVersion
  * @property-read int $StatusCode

--- a/src/Http/HttpServer.php
+++ b/src/Http/HttpServer.php
@@ -10,7 +10,7 @@ use Lkrms\Http\Catalog\HttpRequestMethodGroup;
 use RuntimeException;
 
 /**
- * Listen for HTTP requests on a local address
+ * Listens for HTTP requests on a local address
  *
  * @property-read string $Host
  * @property-read int $Port


### PR DESCRIPTION
- In `File::close()`, make `$filename` optional and rename it to `$uri`
- In `File::writeCsv()`, use `php://temp` instead of `php://memory` for temporary output
- Add `File::write()`, `File::seek()`, `File::tell()`
- Fix issue where `File::getStreamUri()` fails for streams with no URI

Also:
- Make `FilesystemErrorException` (and most other exceptions) extend `RuntimeException` instead of `Exception`
- Fix issue where `Arrayable` objects cannot be applied to collections