### PR TITLE
Address minor bugs and inconsistencies identified downstream

### DIFF
--- a/src/Cli/CliCommand.php
+++ b/src/Cli/CliCommand.php
@@ -562,20 +562,20 @@ abstract class CliCommand implements ICliCommand
                     if ($short !== null) {
                         $line[] = "{$b}-{$short}{$b}";
                         $value[] = $option->ValueRequired
-                            ? "{$esc} {}{$ellipsis}"
+                            ? " {}{$ellipsis}"
                             : "{$esc}[{}{$ellipsis}]";
                     }
 
                     if ($long !== null) {
                         $line[] = "{$b}--{$long}{$b}";
                         $value[] = $option->ValueRequired
-                            ? "{$esc} {}{$ellipsis}"
+                            ? " {}{$ellipsis}"
                             : "{$esc}[={}{$ellipsis}]";
                     }
                 }
             }
 
-            $line = $prefix . implode(",{$esc} ", $line) . array_pop($value) . $suffix;
+            $line = $prefix . implode(', ', $line) . array_pop($value) . $suffix;
 
             // Replace value name with allowed values if $synopsis won't break
             // over multiple lines, otherwise add them after the description
@@ -625,14 +625,20 @@ abstract class CliCommand implements ICliCommand
                 (!($option->Visibility & CliOptionVisibility::HIDE_DEFAULT) ||
                     $visibility === CliOptionVisibility::HELP)) {
                 foreach ((array) $option->DefaultValue as $value) {
+                    if ((string) $value === '') {
+                        continue;
+                    }
                     $default[] = $em . $formatter->escapeTags((string) $value) . $em;
                 }
-                $lines[] = sprintf(
-                    "%sThe default %s is:{$esc} %s",
-                    $indent,
-                    $valueName,
-                    implode($option->Delimiter ?? ' ', $default)
-                );
+                $default = implode($option->Delimiter ?? ' ', $default);
+                if ($default !== '') {
+                    $lines[] = sprintf(
+                        '%sThe default %s is: %s',
+                        $indent,
+                        $valueName,
+                        $default,
+                    );
+                }
             }
 
             $options[] = $beforeSynopsis . $synopsis

--- a/src/Concern/TCollection.php
+++ b/src/Concern/TCollection.php
@@ -22,14 +22,6 @@ trait TCollection
     use TReadableCollection;
 
     /**
-     * @param Arrayable<TKey,TValue>|iterable<TKey,TValue> $items
-     */
-    public function __construct($items = [])
-    {
-        $this->Items = $this->getItems($items);
-    }
-
-    /**
      * @param TKey $key
      * @param TValue $value
      * @return static
@@ -198,24 +190,6 @@ trait TCollection
     }
 
     // --
-
-    /**
-     * @param Arrayable<TKey,TValue>|iterable<TKey,TValue> $items
-     * @return array<TKey,TValue>
-     */
-    protected function getItems($items): array
-    {
-        if ($items instanceof self) {
-            return $items->Items;
-        }
-        if ($items instanceof Arrayable) {
-            return $items->toArray();
-        }
-        if (is_array($items)) {
-            return $items;
-        }
-        return iterator_to_array($items);
-    }
 
     /**
      * @param array<TKey,TValue> $items

--- a/src/Concern/TReadableCollection.php
+++ b/src/Concern/TReadableCollection.php
@@ -28,6 +28,22 @@ trait TReadableCollection
     protected $Items = [];
 
     /**
+     * @param Arrayable<TKey,TValue>|iterable<TKey,TValue> $items
+     */
+    public function __construct($items = [])
+    {
+        $this->Items = $this->getItems($items);
+    }
+
+    /**
+     * @return static
+     */
+    public static function empty()
+    {
+        return new static();
+    }
+
+    /**
      * @param ((callable(TValue, TValue|null $nextValue, TValue|null $prevValue): mixed)|(callable(TKey, TKey|null $nextKey, TKey|null $prevKey): mixed)|(callable(array<TKey,TValue>, array<TKey,TValue>|null $nextItem, array<TKey,TValue>|null $prevItem): mixed)) $callback
      * @param ICollection::CALLBACK_USE_* $mode
      * @return $this
@@ -276,6 +292,24 @@ trait TReadableCollection
     // --
 
     /**
+     * @param Arrayable<TKey,TValue>|iterable<TKey,TValue> $items
+     * @return array<TKey,TValue>
+     */
+    protected function getItems($items): array
+    {
+        if ($items instanceof self) {
+            return $items->Items;
+        }
+        if ($items instanceof Arrayable) {
+            return $items->toArray();
+        }
+        if (is_array($items)) {
+            return $items;
+        }
+        return iterator_to_array($items);
+    }
+
+    /**
      * Compare items using IComparable::compare() if implemented
      *
      * @param TValue $a
@@ -294,7 +328,6 @@ trait TReadableCollection
                 return $b->compare($a, $b);
             }
         }
-
         return $a <=> $b;
     }
 }

--- a/src/Contract/ICollection.php
+++ b/src/Contract/ICollection.php
@@ -35,6 +35,18 @@ interface ICollection extends ArrayAccess, Arrayable, Countable, IteratorAggrega
     public const CALLBACK_USE_BOTH = 2;
 
     /**
+     * @param Arrayable<TKey,TValue>|iterable<TKey,TValue> $items
+     */
+    public function __construct($items = []);
+
+    /**
+     * Get a new collection with no items
+     *
+     * @return static
+     */
+    public static function empty();
+
+    /**
      * Add or replace an item with a given key
      *
      * @param TKey $key

--- a/src/Http/Auth/OAuth2Client.php
+++ b/src/Http/Auth/OAuth2Client.php
@@ -639,7 +639,7 @@ abstract class OAuth2Client
         if (is_string($scopes)) {
             return Arr::trim(explode(' ', $scopes));
         }
-        if (!Arr::listOfString($scopes, true)) {
+        if (!Arr::isListOfString($scopes, true)) {
             throw new InvalidArgumentException(sprintf(
                 'Argument #1 ($scopes) must be of type string[]|string|null, %s given',
                 Inspect::getType($scopes),

--- a/src/Sync/Concept/SyncEntity.php
+++ b/src/Sync/Concept/SyncEntity.php
@@ -40,7 +40,6 @@ use Lkrms\Sync\Support\SyncStore;
 use Lkrms\Utility\Arr;
 use Lkrms\Utility\Convert;
 use Lkrms\Utility\Pcre;
-use Lkrms\Utility\Test;
 use Closure;
 use DateTimeInterface;
 use Generator;
@@ -576,7 +575,7 @@ abstract class SyncEntity extends Entity implements ISyncEntity, ReturnsNormalis
             return;
         }
 
-        if (Test::isArrayOf($node, SyncEntity::class, true) && Arr::isIndexed($node, true)) {
+        if (Arr::of($node, SyncEntity::class, true) && Arr::isIndexed($node, true)) {
             /** @var SyncEntity $child */
             foreach ($node as &$child) {
                 $child = $child->Id;

--- a/src/Sync/Support/SyncContext.php
+++ b/src/Sync/Support/SyncContext.php
@@ -12,7 +12,6 @@ use Lkrms\Sync\Exception\SyncInvalidFilterException;
 use Lkrms\Utility\Arr;
 use Lkrms\Utility\Convert;
 use Lkrms\Utility\Pcre;
-use Lkrms\Utility\Test;
 use LogicException;
 
 /**
@@ -146,7 +145,7 @@ final class SyncContext extends ProviderContext implements ISyncContext
             return $this->applyFilters(['id' => $args]);
         }
 
-        if (Test::isArrayOf($args, ISyncEntity::class)) {
+        if (Arr::of($args, ISyncEntity::class)) {
             return $this->applyFilters(
                 array_merge_recursive(
                     ...array_map(
@@ -293,7 +292,7 @@ final class SyncContext extends ProviderContext implements ISyncContext
         if ($value instanceof ISyncEntity) {
             return $value->id();
         }
-        if (Test::isArrayOf($value, ISyncEntity::class)) {
+        if (Arr::of($value, ISyncEntity::class)) {
             $ids = [];
             /** @var ISyncEntity $entity */
             foreach ($value as $entity) {

--- a/src/Utility/Arr.php
+++ b/src/Utility/Arr.php
@@ -326,11 +326,11 @@ final class Arr
      *
      * @param mixed $value
      */
-    public static function listOfArrayKey($value, bool $orEmpty = false): bool
+    public static function isListOfArrayKey($value, bool $orEmpty = false): bool
     {
         return
-            self::listOfInt($value, $orEmpty) ||
-            self::listOfString($value);
+            self::isListOfInt($value, $orEmpty) ||
+            self::isListOfString($value);
     }
 
     /**
@@ -340,7 +340,7 @@ final class Arr
      */
     public static function ofInt($value, bool $orEmpty = false): bool
     {
-        return self::doOfType('is_int', $value, $orEmpty, false);
+        return self::doIsArrayOf('is_int', $value, $orEmpty, false);
     }
 
     /**
@@ -348,9 +348,9 @@ final class Arr
      *
      * @param mixed $value
      */
-    public static function listOfInt($value, bool $orEmpty = false): bool
+    public static function isListOfInt($value, bool $orEmpty = false): bool
     {
-        return self::doOfType('is_int', $value, $orEmpty, true);
+        return self::doIsArrayOf('is_int', $value, $orEmpty, true);
     }
 
     /**
@@ -360,7 +360,7 @@ final class Arr
      */
     public static function ofString($value, bool $orEmpty = false): bool
     {
-        return self::doOfType('is_string', $value, $orEmpty, false);
+        return self::doIsArrayOf('is_string', $value, $orEmpty, false);
     }
 
     /**
@@ -368,15 +368,44 @@ final class Arr
      *
      * @param mixed $value
      */
-    public static function listOfString($value, bool $orEmpty = false): bool
+    public static function isListOfString($value, bool $orEmpty = false): bool
     {
-        return self::doOfType('is_string', $value, $orEmpty, true);
+        return self::doIsArrayOf('is_string', $value, $orEmpty, true);
+    }
+
+    /**
+     * True if a value is an array of instances of a given class
+     *
+     * @template T of object
+     *
+     * @param mixed $value
+     * @param class-string<T> $class
+     * @phpstan-assert-if-true T[] $value
+     */
+    public static function of($value, string $class, bool $orEmpty = false): bool
+    {
+        return self::doIsArrayOf('is_a', $value, $orEmpty, false, $class);
+    }
+
+    /**
+     * True if a value is a list of instances of a given class
+     *
+     * @template T of object
+     *
+     * @param mixed $value
+     * @param class-string<T> $class
+     * @phpstan-assert-if-true list<T> $value
+     */
+    public static function isListOf($value, string $class, bool $orEmpty = false): bool
+    {
+        return self::doIsArrayOf('is_a', $value, $orEmpty, true, $class);
     }
 
     /**
      * @param mixed $value
+     * @param mixed ...$args
      */
-    private static function doOfType(string $func, $value, bool $orEmpty, bool $requireList): bool
+    private static function doIsArrayOf(string $func, $value, bool $orEmpty, bool $requireList, ...$args): bool
     {
         if (!is_array($value)) {
             return false;
@@ -389,7 +418,7 @@ final class Arr
             if ($requireList && $i++ !== $key) {
                 return false;
             }
-            if (!$func($value)) {
+            if (!$func($value, ...$args)) {
                 return false;
             }
         }

--- a/src/Utility/Test.php
+++ b/src/Utility/Test.php
@@ -112,29 +112,16 @@ final class Test
     }
 
     /**
-     * True if $value is an array of $class instances
-     *
      * @template T of object
-     *
      * @param mixed $value
      * @param class-string<T> $class
      * @phpstan-assert-if-true T[] $value
+     * @deprecated Use {@see Arr::of()} instead
+     * @codeCoverageIgnore
      */
     public static function isArrayOf($value, string $class, bool $allowEmpty = false): bool
     {
-        if (!is_array($value)) {
-            return false;
-        }
-        if (!$value) {
-            return $allowEmpty;
-        }
-        foreach ($value as $item) {
-            if (!is_a($item, $class)) {
-                return false;
-            }
-        }
-
-        return true;
+        return Arr::of($value, $class, $allowEmpty);
     }
 
     /**

--- a/tests/unit/Utility/ArrTest.php
+++ b/tests/unit/Utility/ArrTest.php
@@ -3,6 +3,8 @@
 namespace Lkrms\Tests\Utility;
 
 use Lkrms\Utility\Arr;
+use DateTimeImmutable;
+use DateTimeInterface;
 
 final class ArrTest extends \Lkrms\Tests\TestCase
 {
@@ -176,29 +178,40 @@ final class ArrTest extends \Lkrms\Tests\TestCase
      *
      * @param mixed $value
      */
-    public function testOfArrayKey($value, bool $expected, bool $expectedIfAllowEmpty): void
-    {
+    public function testOfArrayKey(
+        $value,
+        bool $expected,
+        bool $expectedIfOrEmpty,
+        bool $expectedIfList,
+        bool $expectedIfOrEmptyList
+    ): void {
         $this->assertSame($expected, Arr::ofArrayKey($value));
-        $this->assertSame($expectedIfAllowEmpty, Arr::ofArrayKey($value, true));
+        $this->assertSame($expectedIfOrEmpty, Arr::ofArrayKey($value, true));
+        $this->assertSame($expectedIfList, Arr::isListOfArrayKey($value));
+        $this->assertSame($expectedIfOrEmptyList, Arr::isListOfArrayKey($value, true));
     }
 
     /**
-     * @return array<string,array{mixed,bool,bool}>
+     * @return array<string,array{mixed,bool,bool,bool,bool}>
      */
     public static function ofArrayKeyProvider(): array
     {
         return [
-            'null' => [null, false, false],
-            'int' => [0, false, false],
-            'string' => ['a', false, false],
-            'empty' => [[], false, true],
-            'ints' => [[0, 1], true, true],
-            'strings' => [['a', 'b'], true, true],
-            'mixed #1' => [[0, 'a'], false, false],
-            'mixed #2' => [[0, 1, true], false, false],
-            'mixed #3' => [[0, 1, null], false, false],
-            'mixed #4' => [['a', 'b', true], false, false],
-            'mixed #5' => [['a', 'b', null], false, false],
+            'null' => [null, false, false, false, false],
+            'int' => [0, false, false, false, false],
+            'string' => ['a', false, false, false, false],
+            'empty' => [[], false, true, false, true],
+            'ints' => [[0, 1], true, true, true, true],
+            'ints (indexed)' => [[7 => 0, 1 => 1], true, true, false, false],
+            'ints (associative)' => [['a' => 0, 'b' => 1], true, true, false, false],
+            'strings' => [['a', 'b'], true, true, true, true],
+            'strings (indexed)' => [[7 => 'a', 1 => 'b'], true, true, false, false],
+            'strings (associative)' => [['a' => 'a', 'b' => 'b'], true, true, false, false],
+            'mixed #1' => [[0, 'a'], false, false, false, false],
+            'mixed #2' => [[0, 1, true], false, false, false, false],
+            'mixed #3' => [[0, 1, null], false, false, false, false],
+            'mixed #4' => [['a', 'b', true], false, false, false, false],
+            'mixed #5' => [['a', 'b', null], false, false, false, false],
         ];
     }
 
@@ -207,29 +220,38 @@ final class ArrTest extends \Lkrms\Tests\TestCase
      *
      * @param mixed $value
      */
-    public function testOfInt($value, bool $expected, bool $expectedIfAllowEmpty): void
-    {
+    public function testOfInt(
+        $value,
+        bool $expected,
+        bool $expectedIfOrEmpty,
+        bool $expectedIfList,
+        bool $expectedIfOrEmptyList
+    ): void {
         $this->assertSame($expected, Arr::ofInt($value));
-        $this->assertSame($expectedIfAllowEmpty, Arr::ofInt($value, true));
+        $this->assertSame($expectedIfOrEmpty, Arr::ofInt($value, true));
+        $this->assertSame($expectedIfList, Arr::isListOfInt($value));
+        $this->assertSame($expectedIfOrEmptyList, Arr::isListOfInt($value, true));
     }
 
     /**
-     * @return array<string,array{mixed,bool,bool}>
+     * @return array<string,array{mixed,bool,bool,bool,bool}>
      */
     public static function ofIntProvider(): array
     {
         return [
-            'null' => [null, false, false],
-            'int' => [0, false, false],
-            'string' => ['a', false, false],
-            'empty' => [[], false, true],
-            'ints' => [[0, 1], true, true],
-            'strings' => [['a', 'b'], false, false],
-            'mixed #1' => [[0, 'a'], false, false],
-            'mixed #2' => [[0, 1, true], false, false],
-            'mixed #3' => [[0, 1, null], false, false],
-            'mixed #4' => [['a', 'b', true], false, false],
-            'mixed #5' => [['a', 'b', null], false, false],
+            'null' => [null, false, false, false, false],
+            'int' => [0, false, false, false, false],
+            'string' => ['a', false, false, false, false],
+            'empty' => [[], false, true, false, true],
+            'ints' => [[0, 1], true, true, true, true],
+            'ints (indexed)' => [[7 => 0, 1 => 1], true, true, false, false],
+            'ints (associative)' => [['a' => 0, 'b' => 1], true, true, false, false],
+            'strings' => [['a', 'b'], false, false, false, false],
+            'mixed #1' => [[0, 'a'], false, false, false, false],
+            'mixed #2' => [[0, 1, true], false, false, false, false],
+            'mixed #3' => [[0, 1, null], false, false, false, false],
+            'mixed #4' => [['a', 'b', true], false, false, false, false],
+            'mixed #5' => [['a', 'b', null], false, false, false, false],
         ];
     }
 
@@ -238,29 +260,38 @@ final class ArrTest extends \Lkrms\Tests\TestCase
      *
      * @param mixed $value
      */
-    public function testOfString($value, bool $expected, bool $expectedIfAllowEmpty): void
-    {
+    public function testOfString(
+        $value,
+        bool $expected,
+        bool $expectedIfOrEmpty,
+        bool $expectedIfList,
+        bool $expectedIfOrEmptyList
+    ): void {
         $this->assertSame($expected, Arr::ofString($value));
-        $this->assertSame($expectedIfAllowEmpty, Arr::ofString($value, true));
+        $this->assertSame($expectedIfOrEmpty, Arr::ofString($value, true));
+        $this->assertSame($expectedIfList, Arr::isListOfString($value));
+        $this->assertSame($expectedIfOrEmptyList, Arr::isListOfString($value, true));
     }
 
     /**
-     * @return array<string,array{mixed,bool,bool}>
+     * @return array<string,array{mixed,bool,bool,bool,bool}>
      */
     public static function ofStringProvider(): array
     {
         return [
-            'null' => [null, false, false],
-            'int' => [0, false, false],
-            'string' => ['a', false, false],
-            'empty' => [[], false, true],
-            'ints' => [[0, 1], false, false],
-            'strings' => [['a', 'b'], true, true],
-            'mixed #1' => [[0, 'a'], false, false],
-            'mixed #2' => [[0, 1, true], false, false],
-            'mixed #3' => [[0, 1, null], false, false],
-            'mixed #4' => [['a', 'b', true], false, false],
-            'mixed #5' => [['a', 'b', null], false, false],
+            'null' => [null, false, false, false, false],
+            'int' => [0, false, false, false, false],
+            'string' => ['a', false, false, false, false],
+            'empty' => [[], false, true, false, true],
+            'ints' => [[0, 1], false, false, false, false],
+            'strings' => [['a', 'b'], true, true, true, true],
+            'strings (indexed)' => [[7 => 'a', 1 => 'b'], true, true, false, false],
+            'strings (associative)' => [['a' => 'a', 'b' => 'b'], true, true, false, false],
+            'mixed #1' => [[0, 'a'], false, false, false, false],
+            'mixed #2' => [[0, 1, true], false, false, false, false],
+            'mixed #3' => [[0, 1, null], false, false, false, false],
+            'mixed #4' => [['a', 'b', true], false, false, false, false],
+            'mixed #5' => [['a', 'b', null], false, false, false, false],
         ];
     }
 
@@ -345,6 +376,52 @@ final class ArrTest extends \Lkrms\Tests\TestCase
                     },
                 ],
             ],
+        ];
+    }
+
+    /**
+     * @dataProvider ofProvider
+     *
+     * @param mixed $value
+     */
+    public function testOf(
+        $value,
+        string $class,
+        bool $expected,
+        bool $expectedIfOrEmpty,
+        bool $expectedIfList,
+        bool $expectedIfOrEmptyList
+    ): void {
+        $this->assertSame($expected, Arr::of($value, $class));
+        $this->assertSame($expectedIfOrEmpty, Arr::of($value, $class, true));
+        $this->assertSame($expectedIfList, Arr::isListOf($value, $class));
+        $this->assertSame($expectedIfOrEmptyList, Arr::isListOf($value, $class, true));
+    }
+
+    /**
+     * @return array<string,array{mixed,string,bool,bool,bool,bool}>
+     */
+    public static function ofProvider(): array
+    {
+        $now = fn() => new DateTimeImmutable();
+
+        return [
+            'null' => [null, DateTimeInterface::class, false, false, false, false],
+            'int' => [0, DateTimeInterface::class, false, false, false, false],
+            'string' => ['a', DateTimeInterface::class, false, false, false, false],
+            'empty' => [[], DateTimeInterface::class, false, true, false, true],
+            'ints' => [[0, 1], DateTimeInterface::class, false, false, false, false],
+            'strings' => [['a', 'b'], DateTimeInterface::class, false, false, false, false],
+            'datetimes' => [[$now(), $now()], DateTimeInterface::class, true, true, true, true],
+            'datetimes (indexed)' => [[7 => $now(), 1 => $now()], DateTimeInterface::class, true, true, false, false],
+            'datetimes (associative)' => [['from' => $now(), 'to' => $now()], DateTimeInterface::class, true, true, false, false],
+            'mixed #1' => [[0, 'a', $now()], DateTimeInterface::class, false, false, false, false],
+            'mixed #2' => [[0, 1, true], DateTimeInterface::class, false, false, false, false],
+            'mixed #3' => [[0, 1, null], DateTimeInterface::class, false, false, false, false],
+            'mixed #4' => [['a', 'b', true], DateTimeInterface::class, false, false, false, false],
+            'mixed #5' => [['a', 'b', null], DateTimeInterface::class, false, false, false, false],
+            'mixed #6' => [[$now, $now, true], DateTimeInterface::class, false, false, false, false],
+            'mixed #7' => [[$now, $now, null], DateTimeInterface::class, false, false, false, false],
         ];
     }
 

--- a/tests/unit/Utility/TestTest.php
+++ b/tests/unit/Utility/TestTest.php
@@ -3,8 +3,6 @@
 namespace Lkrms\Tests\Utility;
 
 use Lkrms\Utility\Test;
-use DateTimeImmutable;
-use DateTimeInterface;
 
 final class TestTest extends \Lkrms\Tests\TestCase
 {
@@ -102,42 +100,6 @@ final class TestTest extends \Lkrms\Tests\TestCase
             [true, 0],
             [true, 1],
             [true, 71],
-        ];
-    }
-
-    /**
-     * @dataProvider isArrayOfProvider
-     *
-     * @param mixed $value
-     */
-    public function testIsArrayOf($value, string $class, bool $expected, bool $expectedIfAllowEmpty): void
-    {
-        $this->assertSame($expected, Test::isArrayOf($value, $class));
-        $this->assertSame($expectedIfAllowEmpty, Test::isArrayOf($value, $class, true));
-    }
-
-    /**
-     * @return array<string,array{mixed,string,bool,bool}>
-     */
-    public static function isArrayOfProvider(): array
-    {
-        $now = fn() => new DateTimeImmutable();
-
-        return [
-            'null' => [null, DateTimeInterface::class, false, false],
-            'int' => [0, DateTimeInterface::class, false, false],
-            'string' => ['a', DateTimeInterface::class, false, false],
-            'empty' => [[], DateTimeInterface::class, false, true],
-            'ints' => [[0, 1], DateTimeInterface::class, false, false],
-            'strings' => [['a', 'b'], DateTimeInterface::class, false, false],
-            'datetimes' => [[$now(), $now()], DateTimeInterface::class, true, true],
-            'mixed #1' => [[0, 'a', $now()], DateTimeInterface::class, false, false],
-            'mixed #2' => [[0, 1, true], DateTimeInterface::class, false, false],
-            'mixed #3' => [[0, 1, null], DateTimeInterface::class, false, false],
-            'mixed #4' => [['a', 'b', true], DateTimeInterface::class, false, false],
-            'mixed #5' => [['a', 'b', null], DateTimeInterface::class, false, false],
-            'mixed #6' => [[$now, $now, true], DateTimeInterface::class, false, false],
-            'mixed #7' => [[$now, $now, null], DateTimeInterface::class, false, false],
         ];
     }
 }


### PR DESCRIPTION
- `Cli`: fix issue where empty default values are displayed in help messages
- `Cli`: remove escapes from horizontal whitespace to fix issue where help written as Markdown wraps weirdly when rendered
- Add `ICollection::empty()`
- Add `Arr::of()`, deprecating `Test::isArrayOf()`
- Add `Arr::isListOf()`
- Rename:
  - `Arr::listOfArrayKey()` -> `Arr::isListOfArrayKey()`
  - `Arr::listOfInt()` -> `Arr::isListOfInt()`
  - `Arr::listOfString()` -> `Arr::isListOfString()`