### PR TITLE
Allow exceptions to be thrown with an exit status

### DIFF
--- a/src/Cli/CliCommand.php
+++ b/src/Cli/CliCommand.php
@@ -66,8 +66,8 @@ abstract class CliCommand implements ICliCommand
      * ```php
      * [
      *     CliHelpSectionName::EXIT_STATUS => <<<EOF
-     * `{{command}}` returns 0 when the operation succeeds, 1 when invalid arguments
-     * are given, and 15 when an unhandled exception is thrown. Other non-zero values
+     * `{{program}}` returns 0 when the operation succeeds, 1 when invalid arguments
+     * are given, and 16 when an unhandled exception is thrown. Other non-zero values
      * may be returned for other failures.
      * EOF,
      * ];

--- a/src/Console/Support/ConsoleFormat.php
+++ b/src/Console/Support/ConsoleFormat.php
@@ -52,8 +52,9 @@ final class ConsoleFormat implements IConsoleFormat
             return '';
         }
 
-        // Remove indentation from the first line of code in fenced code blocks
-        // to prevent doubling up
+        // In fenced code blocks:
+        // - remove indentation from the first line of code
+        // - add a level of indentation to the block
         $tagId = $attributes[Attribute::TAG_ID] ?? null;
         if ($tagId === Tag::CODE_BLOCK) {
             $indent = $attributes[Attribute::INDENT] ?? '';
@@ -63,6 +64,7 @@ final class ConsoleFormat implements IConsoleFormat
                     $text = substr($text, $length);
                 }
             }
+            $text = '    ' . str_replace("\n", "\n    ", $text);
         }
 
         if ($this->Replace) {

--- a/src/Exception/Concern/ExceptionTrait.php
+++ b/src/Exception/Concern/ExceptionTrait.php
@@ -12,11 +12,28 @@ use Throwable;
  */
 trait ExceptionTrait
 {
+    protected ?int $ExitStatus = null;
+
     public function __construct(
         string $message = '',
-        ?Throwable $previous = null
+        ?Throwable $previous = null,
+        ?int $exitStatus = null
     ) {
+        $this->ExitStatus = $exitStatus;
         parent::__construct($message, 0, $previous);
+    }
+
+    /**
+     * Set the exit status to return if the exception is not caught on the
+     * command line
+     *
+     * @return static
+     */
+    public function withExitStatus(?int $exitStatus)
+    {
+        $clone = clone $this;
+        $clone->ExitStatus = $exitStatus;
+        return $clone;
     }
 
     /**
@@ -27,6 +44,14 @@ trait ExceptionTrait
     public function getDetail(): array
     {
         return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getExitStatus(): ?int
+    {
+        return $this->ExitStatus;
     }
 
     /**

--- a/src/Exception/Contract/ExceptionInterface.php
+++ b/src/Exception/Contract/ExceptionInterface.php
@@ -12,4 +12,10 @@ interface ExceptionInterface extends Throwable
      * @return array<string,string>
      */
     public function getDetail(): array;
+
+    /**
+     * Get the exit status to return if the exception is not caught on the
+     * command line
+     */
+    public function getExitStatus(): ?int;
 }

--- a/src/Support/ErrorHandler.php
+++ b/src/Support/ErrorHandler.php
@@ -4,6 +4,7 @@ namespace Lkrms\Support;
 
 use Lkrms\Contract\IFacade;
 use Lkrms\Contract\ReceivesFacade;
+use Lkrms\Exception\Contract\ExceptionInterface;
 use Lkrms\Facade\Console;
 use Lkrms\Utility\File;
 use Lkrms\Utility\Pcre;
@@ -29,7 +30,7 @@ final class ErrorHandler implements ReceivesFacade
      */
     private array $Silenced = [];
 
-    private int $ExitStatus = 15;
+    private int $ExitStatus = 16;
 
     private bool $IsRegistered = false;
 
@@ -197,6 +198,12 @@ final class ErrorHandler implements ReceivesFacade
         Console::exception($exception);
 
         if (!$this->IsShuttingDown) {
+            if ($exception instanceof ExceptionInterface) {
+                $exitStatus = $exception->getExitStatus();
+                if ($exitStatus !== null) {
+                    exit ($exitStatus);
+                }
+            }
             exit ($this->ExitStatus);
         }
     }

--- a/src/Sync/Command/CheckSyncProviderHeartbeat.php
+++ b/src/Sync/Command/CheckSyncProviderHeartbeat.php
@@ -93,7 +93,7 @@ final class CheckSyncProviderHeartbeat extends AbstractSyncCommand
         return
             ($description ?? '') . <<<EOF
                 If a heartbeat request fails, __{{command}}__ continues to the next
-                provider unless --fail-early is given, in which case it exits
+                provider unless `-f/--fail-early` is given, in which case it exits
                 immediately.
 
                 The command exits with a non-zero status if a provider backend is

--- a/tests/unit/Console/ConsoleFormatterTest.php
+++ b/tests/unit/Console/ConsoleFormatterTest.php
@@ -68,7 +68,7 @@ final class ConsoleFormatterTest extends \Lkrms\Tests\TestCase
             *0*   escapes \
             *1*   with \
             *2*   adjacent \
-            *15*  tags
+            *16*  tags
             EOF;
 
         return [
@@ -84,9 +84,9 @@ final class ConsoleFormatterTest extends \Lkrms\Tests\TestCase
 
                 Low-priority information with embedded tags.
 
-                <?php
-                /**Preformatted code block**/
-                $a = b($c);
+                    <?php
+                    /**Preformatted code block**/
+                    $a = b($c);
 
                 HEADING 3
 
@@ -94,9 +94,9 @@ final class ConsoleFormatterTest extends \Lkrms\Tests\TestCase
 
                     Indented _code span_
 
-                    <?php
-                    /**Indented code block**/
-                    $a = b($c);
+                        <?php
+                        /**Indented code block**/
+                        $a = b($c);
 
                 Bold, italic and underline.
 
@@ -108,7 +108,7 @@ final class ConsoleFormatterTest extends \Lkrms\Tests\TestCase
                 0   escapes
                 1   with
                 2   adjacent
-                15  tags
+                16  tags
                 EOF,
                 $default,
                 $input,
@@ -153,7 +153,7 @@ final class ConsoleFormatterTest extends \Lkrms\Tests\TestCase
                 *0*   escapes \
                 *1*   with \
                 *2*   adjacent \
-                *15*  tags
+                *16*  tags
                 EOF,
                 $loopback,
                 $input,


### PR DESCRIPTION
- Add `ExceptionInterface::getExitStatus()` and implement via `ExceptionTrait::withExitStatus()`
- In `ErrorHandler::handleException()`, use the value returned by `ExceptionInterface::getExitStatus()` if not `null`

Also:
- `Console`: indent fenced code blocks
- Adopt 16 instead of 15 as `ErrorHandler`'s default exit status to better accommodate bitmasks as return values