### PR TITLE
Cli: build out JSON Schema support

### DIFF
--- a/src/Cli/Catalog/CliOptionValueType.php
+++ b/src/Cli/Catalog/CliOptionValueType.php
@@ -3,6 +3,7 @@
 namespace Lkrms\Cli\Catalog;
 
 use Lkrms\Concept\ConvertibleEnumeration;
+use LogicException;
 
 /**
  * Command line option value types
@@ -88,4 +89,33 @@ final class CliOptionValueType extends ConvertibleEnumeration
         'PATH_OR_DASH' => self::PATH_OR_DASH,
         'FILE_OR_DASH' => self::FILE_OR_DASH,
     ];
+
+    /**
+     * @var array<CliOptionValueType::*,string>
+     */
+    private static $JsonSchemaTypeMap = [
+        self::BOOLEAN => 'boolean',
+        self::INTEGER => 'integer',
+        self::STRING => 'string',
+        self::DATE => 'string',
+        self::PATH => 'string',
+        self::FILE => 'string',
+        self::DIRECTORY => 'string',
+        self::PATH_OR_DASH => 'string',
+        self::FILE_OR_DASH => 'string',
+    ];
+
+    /**
+     * Convert a value type to a JSON Schema type
+     *
+     * @param CliOptionValueType::* $type
+     */
+    public static function toJsonSchemaType($type): string
+    {
+        $jsonSchemaType = self::$JsonSchemaTypeMap[$type] ?? null;
+        if ($jsonSchemaType === null) {
+            throw new LogicException(sprintf('Invalid CliOptionValueType: %d', $type));
+        }
+        return $jsonSchemaType;
+    }
 }

--- a/src/Cli/CliApplication.php
+++ b/src/Cli/CliApplication.php
@@ -15,6 +15,7 @@ use Lkrms\Facade\Console;
 use Lkrms\Utility\Catalog\EnvFlag;
 use Lkrms\Utility\Arr;
 use Lkrms\Utility\Assert;
+use Lkrms\Utility\Json;
 use Lkrms\Utility\Package;
 use Lkrms\Utility\Pcre;
 use Lkrms\Utility\Sys;
@@ -424,25 +425,34 @@ class CliApplication extends Application implements ICliApplication
             $name .= ($name === '' ? '' : ' ') . $arg;
         }
 
-        if (($args[0] ?? null) === '_md') {
+        if ($args && $args[0] === '_md') {
             array_shift($args);
             $this->generateHelp($name, $node, CliHelpType::MARKDOWN, ...$args);
             return $this;
         }
 
-        if (($args[0] ?? null) === '_man') {
+        if ($args && $args[0] === '_man') {
             array_shift($args);
             $this->generateHelp($name, $node, CliHelpType::MAN_PAGE, ...$args);
             return $this;
         }
 
         $command = $this->getNodeCommand($name, $node);
+
         try {
             if (!$command) {
                 throw new CliInvalidArgumentsException(
                     sprintf('no command registered: %s', $name)
                 );
             }
+
+            if ($args && $args[0] === '_json_schema') {
+                array_shift($args);
+                $schema = $command->getJsonSchema($args[0] ?? trim($this->getProgramName() . " $name") . ' options');
+                printf("%s\n", Json::prettyPrint($schema));
+                return $this;
+            }
+
             $this->RunningCommand = $command;
             $this->LastExitStatus = $command(...$args);
             return $this;

--- a/src/Cli/Contract/ICliApplication.php
+++ b/src/Cli/Contract/ICliApplication.php
@@ -92,7 +92,7 @@ interface ICliApplication extends IApplication
     public function buildHelp(array $sections): string;
 
     /**
-     * Process command-line arguments passed to the script and record a return
+     * Process command line arguments passed to the script and record a return
      * value
      *
      * The first applicable action is taken:
@@ -126,7 +126,7 @@ interface ICliApplication extends IApplication
     public function exit();
 
     /**
-     * Exit after processing command-line arguments passed to the script
+     * Exit after processing command line arguments passed to the script
      *
      * The return value recorded by {@see ICliApplication::run()} is used as the
      * exit status.

--- a/src/Cli/Contract/ICliCommand.php
+++ b/src/Cli/Contract/ICliCommand.php
@@ -2,17 +2,15 @@
 
 namespace Lkrms\Cli\Contract;
 
-use Lkrms\Cli\CliCommand;
+use Lkrms\Contract\HasJsonSchema;
 
 /**
  * A runnable CLI command
- *
- * @see CliCommand
  */
-interface ICliCommand extends ICliCommandNode
+interface ICliCommand extends ICliCommandNode, HasJsonSchema
 {
     /**
-     * Parse the arguments and run the command
+     * Parse the given arguments and run the command
      */
     public function __invoke(string ...$args): int;
 }

--- a/src/Cli/Exception/CliInvalidArgumentsException.php
+++ b/src/Cli/Exception/CliInvalidArgumentsException.php
@@ -3,7 +3,7 @@
 namespace Lkrms\Cli\Exception;
 
 /**
- * Thrown when one or more invalid command-line arguments are given
+ * Thrown when invalid command line arguments are given
  */
 class CliInvalidArgumentsException extends \Lkrms\Exception\MultipleErrorException
 {

--- a/src/Console/ConsoleWriter.php
+++ b/src/Console/ConsoleWriter.php
@@ -12,6 +12,7 @@ use Lkrms\Console\ConsoleFormatter as Formatter;
 use Lkrms\Contract\IFacade;
 use Lkrms\Contract\ReceivesFacade;
 use Lkrms\Exception\Contract\ExceptionInterface;
+use Lkrms\Exception\Contract\MultipleErrorExceptionInterface;
 use Lkrms\Exception\InvalidEnvironmentException;
 use Lkrms\Utility\Arr;
 use Lkrms\Utility\Compute;
@@ -837,7 +838,13 @@ final class ConsoleWriter implements ReceivesFacade
                 $msg2 .= sprintf("\nCaused by __%s__: ", $class);
             }
 
-            $message = Formatter::escapeTags($ex->getMessage());
+            if ($ex instanceof MultipleErrorExceptionInterface &&
+                    !$ex->hasUnreportedErrors()) {
+                $message = Formatter::escapeTags($ex->getMessageWithoutErrors());
+            } else {
+                $message = Formatter::escapeTags($ex->getMessage());
+            }
+
             $file = Formatter::escapeTags($ex->getFile());
             $line = $ex->getLine();
             $msg2 .= sprintf('%s ~~in %s:%d~~', $message, $file, $line);

--- a/src/Contract/HasJsonSchema.php
+++ b/src/Contract/HasJsonSchema.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\Contract;
+
+interface HasJsonSchema
+{
+    /**
+     * Get the object's JSON Schema
+     *
+     * @return array<string,mixed>
+     */
+    public function getJsonSchema(): array;
+}

--- a/src/Exception/Concern/MultipleErrorExceptionTrait.php
+++ b/src/Exception/Concern/MultipleErrorExceptionTrait.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\Exception\Concern;
+
+use Lkrms\Console\Catalog\ConsoleLevel as Level;
+use Lkrms\Console\Catalog\ConsoleMessageType as MessageType;
+use Lkrms\Exception\Contract\MultipleErrorExceptionInterface;
+use Lkrms\Facade\Console;
+use Lkrms\Utility\Convert;
+use Lkrms\Utility\Format;
+
+/**
+ * Implements MultipleErrorExceptionInterface
+ *
+ * @see MultipleErrorExceptionInterface
+ */
+trait MultipleErrorExceptionTrait
+{
+    protected ?string $MessageWithoutErrors = null;
+
+    /**
+     * @var string[]
+     */
+    protected array $Errors = [];
+
+    protected bool $HasUnreportedErrors = true;
+
+    public function __construct(
+        string $message = '',
+        string ...$errors
+    ) {
+        $message = rtrim($message, ':');
+        $this->MessageWithoutErrors = $message;
+        $this->Errors = $errors;
+
+        switch (count($errors)) {
+            case 0:
+                break;
+
+            case 1:
+                $message .= ': ' . reset($errors);
+                break;
+
+            default:
+                $message .= ":\n" . rtrim(Format::list($errors));
+                break;
+        }
+
+        parent::__construct($message);
+    }
+
+    public function getMessageWithoutErrors(): string
+    {
+        return Convert::coalesce($this->MessageWithoutErrors, $this->message);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getErrors(): array
+    {
+        return $this->Errors;
+    }
+
+    /**
+     * @return $this
+     */
+    public function reportErrors()
+    {
+        foreach ($this->Errors as $error) {
+            Console::message(Level::ERROR, '__Error:__', $error, MessageType::UNFORMATTED);
+        }
+        $this->HasUnreportedErrors = false;
+        return $this;
+    }
+
+    public function hasUnreportedErrors(): bool
+    {
+        return $this->HasUnreportedErrors;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function getDetail(): array
+    {
+        return [
+            'Errors' => Format::list($this->Errors),
+        ];
+    }
+}

--- a/src/Exception/Contract/MultipleErrorExceptionInterface.php
+++ b/src/Exception/Contract/MultipleErrorExceptionInterface.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\Exception\Contract;
+
+interface MultipleErrorExceptionInterface extends ExceptionInterface
+{
+    /**
+     * Get the original exception message
+     */
+    public function getMessageWithoutErrors(): string;
+
+    /**
+     * Get the exception's errors
+     *
+     * @return string[]
+     */
+    public function getErrors(): array;
+
+    /**
+     * Report the exception's errors with console message level ERROR
+     *
+     * @return $this
+     */
+    public function reportErrors();
+
+    /**
+     * True if the exception's errors have not been reported
+     *
+     * This method should return `false` if {@see reportErrors()} has been
+     * called.
+     */
+    public function hasUnreportedErrors(): bool;
+}

--- a/src/Exception/MultipleErrorException.php
+++ b/src/Exception/MultipleErrorException.php
@@ -2,56 +2,13 @@
 
 namespace Lkrms\Exception;
 
-use Lkrms\Console\Catalog\ConsoleLevel as Level;
-use Lkrms\Console\Catalog\ConsoleMessageType as MessageType;
-use Lkrms\Facade\Console;
+use Lkrms\Exception\Concern\MultipleErrorExceptionTrait;
+use Lkrms\Exception\Contract\MultipleErrorExceptionInterface;
 
 /**
  * Base class for exceptions that represent multiple errors
  */
-abstract class MultipleErrorException extends \Lkrms\Exception\Exception
+abstract class MultipleErrorException extends \Lkrms\Exception\Exception implements MultipleErrorExceptionInterface
 {
-    /**
-     * @var string[]
-     */
-    protected $Errors = [];
-
-    public function __construct(string $message = '', string ...$errors)
-    {
-        $this->Errors = $errors;
-
-        parent::__construct($message);
-    }
-
-    /**
-     * Get the exception's errors
-     *
-     * @return string[]
-     */
-    public function getErrors(): array
-    {
-        return $this->Errors;
-    }
-
-    /**
-     * Use Console::message() to print "Error: <error>" with level ERROR for
-     * each of the exception's errors
-     *
-     * @return $this
-     * @see Console::message()
-     */
-    public function reportErrors()
-    {
-        foreach ($this->Errors as $error) {
-            Console::message(Level::ERROR, '__Error:__', $error, MessageType::UNFORMATTED);
-        }
-        return $this;
-    }
-
-    public function getDetail(): array
-    {
-        return [
-            'Errors' => implode("\n", $this->Errors),
-        ];
-    }
+    use MultipleErrorExceptionTrait;
 }

--- a/tests/unit/Cli/CliOptionBuilderTest.php
+++ b/tests/unit/Cli/CliOptionBuilderTest.php
@@ -28,6 +28,11 @@ final class CliOptionBuilderTest extends \Lkrms\Tests\TestCase
         $this->assertSame(null, $option->EnvVariable);
         $this->assertSame(null, $option->ValueCallback);
         $this->assertSame(false, $option->IsBound);
+        $this->assertSame([
+            'description' => 'Description of flag.',
+            'type' => 'boolean',
+            'default' => false,
+        ], $option->getJsonSchema());
 
         $option = $this
             ->getFlag()
@@ -42,6 +47,11 @@ final class CliOptionBuilderTest extends \Lkrms\Tests\TestCase
         $this->assertSame(null, $option->EnvVariable);
         $this->assertSame(null, $option->ValueCallback);
         $this->assertSame(false, $option->IsBound);
+        $this->assertSame([
+            'description' => 'Description of flag.',
+            'type' => 'integer',
+            'default' => 0,
+        ], $option->getJsonSchema());
 
         $_ENV[__METHOD__] = '1';
 
@@ -131,6 +141,8 @@ final class CliOptionBuilderTest extends \Lkrms\Tests\TestCase
         $this->assertSame(CliOptionValueType::STRING, $option->ValueType);
         $this->assertSame(true, $option->Required);
         $this->assertSame(true, $option->WasRequired);
+        $this->assertSame(true, $option->ValueRequired);
+        $this->assertSame(false, $option->ValueOptional);
         $this->assertSame(false, $option->MultipleAllowed);
         $this->assertSame(false, $option->Unique);
         $this->assertSame(null, $option->Delimiter);
@@ -139,6 +151,10 @@ final class CliOptionBuilderTest extends \Lkrms\Tests\TestCase
         $this->assertSame(null, $option->EnvVariable);
         $this->assertSame(null, $option->ValueCallback);
         $this->assertSame(false, $option->IsBound);
+        $this->assertSame([
+            'description' => 'Description of <NAME>.',
+            'type' => 'string',
+        ], $option->getJsonSchema());
 
         $option = $this
             ->getValue()
@@ -149,6 +165,8 @@ final class CliOptionBuilderTest extends \Lkrms\Tests\TestCase
         $this->assertSame(CliOptionValueType::STRING, $option->ValueType);
         $this->assertSame(false, $option->Required);
         $this->assertSame(false, $option->WasRequired);
+        $this->assertSame(true, $option->ValueRequired);
+        $this->assertSame(false, $option->ValueOptional);
         $this->assertSame(true, $option->MultipleAllowed);
         $this->assertSame(true, $option->Unique);
         $this->assertSame(':', $option->Delimiter);
@@ -157,6 +175,44 @@ final class CliOptionBuilderTest extends \Lkrms\Tests\TestCase
         $this->assertSame(null, $option->EnvVariable);
         $this->assertSame(null, $option->ValueCallback);
         $this->assertSame(false, $option->IsBound);
+        $this->assertSame([
+            'description' => 'Description of <NAME>.',
+            'type' => 'array',
+            'items' => [
+                'type' => 'string',
+            ],
+            'uniqueItems' => true,
+            'default' => ['today'],
+        ], $option->getJsonSchema());
+
+        $option = $this
+            ->getValue()
+            ->optionType(CliOptionType::VALUE_OPTIONAL)
+            ->required(false)
+            ->load();
+        $this->assertIsValue($option, CliOptionType::VALUE_OPTIONAL);
+        $this->assertSame(CliOptionValueType::STRING, $option->ValueType);
+        $this->assertSame(false, $option->Required);
+        $this->assertSame(false, $option->WasRequired);
+        $this->assertSame(false, $option->ValueRequired);
+        $this->assertSame(true, $option->ValueOptional);
+        $this->assertSame(false, $option->MultipleAllowed);
+        $this->assertSame(false, $option->Unique);
+        $this->assertSame(null, $option->Delimiter);
+        $this->assertSame('today', $option->DefaultValue);
+        $this->assertSame('today', $option->OriginalDefaultValue);
+        $this->assertSame(null, $option->EnvVariable);
+        $this->assertSame(null, $option->ValueCallback);
+        $this->assertSame(false, $option->IsBound);
+        $this->assertSame([
+            'description' => 'Description of <NAME>. The name applied if true or null is: today',
+            'type' => [
+                'string',
+                'boolean',
+                'null',
+            ],
+            'default' => false,
+        ], $option->getJsonSchema());
 
         $bound = null;
         $option = $this
@@ -179,7 +235,10 @@ final class CliOptionBuilderTest extends \Lkrms\Tests\TestCase
         $this->assertSame([], $bound);
     }
 
-    private function assertIsValue(CliOption $option): void
+    /**
+     * @param CliOptionType::* $type
+     */
+    private function assertIsValue(CliOption $option, int $type = CliOptionType::VALUE): void
     {
         // No assertions for:
         // - ValueType
@@ -199,12 +258,10 @@ final class CliOptionBuilderTest extends \Lkrms\Tests\TestCase
         $this->assertSame('v|value', $option->Key);
         $this->assertSame('NAME', $option->ValueName);
         $this->assertSame('--value', $option->DisplayName);
-        $this->assertSame(CliOptionType::VALUE, $option->OptionType);
+        $this->assertSame($type, $option->OptionType);
         $this->assertSame(false, $option->IsFlag);
         $this->assertSame(false, $option->IsOneOf);
         $this->assertSame(false, $option->IsPositional);
-        $this->assertSame(true, $option->ValueRequired);
-        $this->assertSame(false, $option->ValueOptional);
         $this->assertSame('Description of <NAME>', $option->Description);
         $this->assertSame(null, $option->AllowedValues);
         $this->assertSame(true, $option->CaseSensitive);
@@ -241,6 +298,14 @@ final class CliOptionBuilderTest extends \Lkrms\Tests\TestCase
         $this->assertSame(null, $option->EnvVariable);
         $this->assertSame(null, $option->ValueCallback);
         $this->assertSame(false, $option->IsBound);
+        $this->assertSame([
+            'description' => 'Description of items.',
+            'type' => 'array',
+            'items' => [
+                'enum' => ['today', 'yesterday', 'tomorrow', 'ALL'],
+            ],
+            'uniqueItems' => true,
+        ], $option->getJsonSchema());
     }
 
     private function assertIsOneOf(CliOption $option): void


### PR DESCRIPTION
- Add `HasJsonSchema` interface
- Implement `HasJsonSchema` in `CliCommand` and `CliOption`
- `CliApplication`: generate a JSON Schema when `_json_schema` is the first argument after a command
- `CliCommand`: add `filterJsonSchema()`
- `CliOption`: add `getSummary()`

Also:
- Add `MultipleErrorExceptionInterface` and move implementation from `MultipleErrorException` to `MultipleErrorExceptionTrait`
- In `MultipleErrorExceptionTrait`:
  - Add `hasUnreportedErrors()` and `getMessageWithoutErrors()`
  - Fix issue where errors passed to the constructor are not reported if `ErrorHandler` is not handling exceptions (e.g. when running PHPUnit) by adding errors to the exception message
- In `Console::exception()`, use `hasUnreportedErrors()` and `getMessageWithoutErrors()` to ensure errors are only reported once