### PR TITLE
Continue utility class cleanup

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -6,6 +6,7 @@ $finder = (new PhpCsFixer\Finder())
         __DIR__ . '/stubs',
         __DIR__ . '/tests/unit',
         __DIR__ . '/tests/fixtures',
+        __DIR__ . '/tests/3rdparty',
         __DIR__ . '/lk-util',
         __DIR__ . '/scripts',
     ])

--- a/.prettyphp
+++ b/.prettyphp
@@ -5,9 +5,13 @@
         "scripts",
         "src",
         "stubs",
+        "tests/3rdparty",
         "tests/fixtures",
+        "tests/legacy",
         "tests/unit",
+        "tests/phpstan-conditional.php",
         "tools/apigen",
+        ".php-cs-fixer.dist.php",
         "bootstrap.php"
     ],
     "enable": [

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "lkrms/dice": "^4.1.8",
         "psr/container": "^2",
         "psr/event-dispatcher": "^1",
+        "psr/http-factory": "^1",
         "psr/http-message": "^1.1 || ^2",
         "psr/log": "^1"
     },
@@ -25,6 +26,7 @@
         "clue/phar-composer": "^1",
         "firebase/php-jwt": "^6",
         "league/oauth2-client": "^2",
+        "php-http/psr7-integration-tests": "^1.3",
         "phpstan/extension-installer": "^1",
         "phpstan/phpstan": "^1",
         "phpstan/phpstan-deprecation-rules": "^1",
@@ -50,7 +52,8 @@
             "Lkrms\\LkUtil\\": "lk-util/",
             "Lkrms\\Tests\\": [
                 "tests/unit/",
-                "tests/fixtures/"
+                "tests/fixtures/",
+                "tests/3rdparty/"
             ]
         },
         "files": [

--- a/lk-util/Command/Http/SendHttpRequest.php
+++ b/lk-util/Command/Http/SendHttpRequest.php
@@ -10,6 +10,7 @@ use Lkrms\LkUtil\Command\Concept\Command;
 use Lkrms\Sync\Concept\HttpSyncProvider;
 use Lkrms\Utility\Arr;
 use Lkrms\Utility\Convert;
+use Lkrms\Utility\Get;
 
 /**
  * Sends HTTP requests to HTTP sync providers
@@ -147,7 +148,7 @@ final class SendHttpRequest extends Command
 
         if ($this->Paginate) {
             /** @var iterable<array-key,mixed> $result */
-            $array = Convert::iterableToArray($result);
+            $array = Get::array($result);
             $result = $array;
         }
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,8 +10,10 @@ parameters:
 		- scripts
 		- src
 		- stubs
+		- tests/3rdparty
 		- tests/fixtures
 		- tests/unit
+		- tests/phpstan-conditional.php
 		- bootstrap.php
 	ignoreErrors:
 		- "#^Property Lkrms\\\\.+\\\\Command\\\\.+\\:\\:\\$[a-zA-Z0-9_]+ is never written, only read\\.$#"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,15 @@
     <testsuite name="unit">
       <directory>tests/unit</directory>
     </testsuite>
+    <testsuite name="3rdparty">
+      <directory>tests/3rdparty</directory>
+    </testsuite>
   </testsuites>
+  <groups>
+    <exclude>
+      <group>internet</group>
+    </exclude>
+  </groups>
   <coverage
       cacheDirectory="build/cache/coverage"
       pathCoverage="false">
@@ -17,4 +25,24 @@
       <html outputDirectory="build/coverage" />
     </report>
   </coverage>
+  <php>
+    <const
+        name="REQUEST_FACTORY"
+        value="Lkrms\Http\HttpFactory" />
+    <const
+        name="RESPONSE_FACTORY"
+        value="Lkrms\Http\HttpFactory" />
+    <const
+        name="SERVER_REQUEST_FACTORY"
+        value="Lkrms\Http\HttpFactory" />
+    <const
+        name="STREAM_FACTORY"
+        value="Lkrms\Http\HttpFactory" />
+    <const
+        name="UPLOADED_FILE_FACTORY"
+        value="Lkrms\Http\HttpFactory" />
+    <const
+        name="URI_FACTORY"
+        value="Lkrms\Http\HttpFactory" />
+  </php>
 </phpunit>

--- a/src/Http/HttpFactory.php
+++ b/src/Http/HttpFactory.php
@@ -1,0 +1,117 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\Http;
+
+use Lkrms\Exception\MethodNotImplementedException;
+use Lkrms\Utility\File;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestFactoryInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UploadedFileFactoryInterface;
+use Psr\Http\Message\UploadedFileInterface;
+use Psr\Http\Message\UriFactoryInterface;
+use Psr\Http\Message\UriInterface;
+
+class HttpFactory implements
+    RequestFactoryInterface,
+    ResponseFactoryInterface,
+    ServerRequestFactoryInterface,
+    StreamFactoryInterface,
+    UploadedFileFactoryInterface,
+    UriFactoryInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function createRequest(string $method, $uri): RequestInterface
+    {
+        return new HttpRequest($uri, $method);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createResponse(
+        int $code = 200,
+        string $reasonPhrase = ''
+    ): ResponseInterface {
+        throw new MethodNotImplementedException(
+            static::class,
+            __FUNCTION__,
+            ResponseFactoryInterface::class
+        );
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param array<string,mixed> $serverParams
+     */
+    public function createServerRequest(
+        string $method,
+        $uri,
+        array $serverParams = []
+    ): ServerRequestInterface {
+        throw new MethodNotImplementedException(
+            static::class,
+            __FUNCTION__,
+            ServerRequestFactoryInterface::class
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createStream(string $content = ''): StreamInterface
+    {
+        return Stream::fromContents($content);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createStreamFromFile(
+        string $filename,
+        string $mode = 'r'
+    ): StreamInterface {
+        return new Stream(File::open($filename, $mode));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createStreamFromResource($resource): StreamInterface
+    {
+        return new Stream($resource);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createUploadedFile(
+        StreamInterface $stream,
+        ?int $size = null,
+        int $error = \UPLOAD_ERR_OK,
+        ?string $clientFilename = null,
+        ?string $clientMediaType = null
+    ): UploadedFileInterface {
+        throw new MethodNotImplementedException(
+            static::class,
+            __FUNCTION__,
+            UploadedFileFactoryInterface::class
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createUri(string $uri = ''): UriInterface
+    {
+        return (new Uri($uri, false))->normalise();
+    }
+}

--- a/src/Http/HttpHeaders.php
+++ b/src/Http/HttpHeaders.php
@@ -90,7 +90,9 @@ class HttpHeaders implements HttpHeadersInterface, IImmutable
         foreach ($items as $key => $value) {
             $values = (array) $value;
             if (!$values) {
-                continue;
+                throw new InvalidArgumentException(
+                    sprintf('At least one value must be given for HTTP header: %s', $key)
+                );
             }
             $lower = strtolower($key);
             $key = $this->filterName($key);
@@ -171,7 +173,9 @@ class HttpHeaders implements HttpHeadersInterface, IImmutable
     {
         $values = (array) $value;
         if (!$values) {
-            return $this;
+            throw new InvalidArgumentException(
+                sprintf('At least one value must be given for HTTP header: %s', $key)
+            );
         }
         $lower = strtolower($key);
         $headers = $this->Headers;
@@ -189,10 +193,15 @@ class HttpHeaders implements HttpHeadersInterface, IImmutable
      */
     public function set($key, $value)
     {
+        $values = (array) $value;
+        if (!$values) {
+            throw new InvalidArgumentException(
+                sprintf('At least one value must be given for HTTP header: %s', $key)
+            );
+        }
         $lower = strtolower($key);
         $headers = $this->Headers;
         $index = $this->Index;
-        $values = (array) $value;
         if (isset($index[$lower])) {
             // Return `$this` if existing values are being reapplied
             if (count($index[$lower]) === count($values)) {
@@ -255,8 +264,13 @@ class HttpHeaders implements HttpHeadersInterface, IImmutable
         $index = $this->Index;
         $applied = false;
         foreach ($items as $key => $value) {
-            $lower = strtolower($key);
             $values = (array) $value;
+            if (!$values) {
+                throw new InvalidArgumentException(
+                    sprintf('At least one value must be given for HTTP header: %s', $key)
+                );
+            }
+            $lower = strtolower($key);
             if (
                 !$preserveExisting &&
                 // Checking against $this->Index instead of $index means any
@@ -267,10 +281,6 @@ class HttpHeaders implements HttpHeadersInterface, IImmutable
                 $unset[$lower] = true;
                 foreach ($index[$lower] as $i) {
                     unset($headers[$i]);
-                }
-                if (!$values) {
-                    unset($index[$lower]);
-                    continue;
                 }
                 // Maintain the order of $index for comparison
                 $index[$lower] = [];

--- a/src/Http/HttpRequest.php
+++ b/src/Http/HttpRequest.php
@@ -148,8 +148,7 @@ class HttpRequest extends HttpMessage implements RequestInterface
 
     private function filterMethod(string $method): string
     {
-        $method = Str::upper($method);
-        if (!HttpRequestMethod::hasValue($method)) {
+        if (!HttpRequestMethod::hasValue(Str::upper($method))) {
             throw new InvalidArgumentException(
                 sprintf('Invalid HTTP method: %s', $method)
             );
@@ -213,8 +212,8 @@ class HttpRequest extends HttpMessage implements RequestInterface
     {
         // `UriInterface` makes no distinction between empty and undefined URI
         // components, but `/path?` and `/path` are not necessarily equivalent,
-        // so URIs are always converted to instances of `Uri`, which surfaces
-        // empty and undefined queries as `""` and `null` respectively
-        return Uri::from($uri);
+        // so URIs are always converted to instances of `Lkrms\Http\Uri`, which
+        // surfaces empty and undefined queries as `""` and `null` respectively
+        return Uri::from($uri)->normalise();
     }
 }

--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -443,6 +443,11 @@ class Uri implements JsonSerializable, Stringable, UriInterface
      */
     public function removeDotSegments(): self
     {
+        // Relative references can only be resolved relative to an absolute URI
+        if ($this->isReference()) {
+            return $this;
+        }
+
         return $this->withPath(File::resolve($this->Path, true));
     }
 

--- a/src/Iterator/Contract/FluentIteratorInterface.php
+++ b/src/Iterator/Contract/FluentIteratorInterface.php
@@ -17,41 +17,27 @@ use Traversable;
 interface FluentIteratorInterface extends Arrayable, Traversable
 {
     /**
-     * Copy the elements of the iterator to an array
+     * Copy the iterator's elements to an array
      *
      * @return ($preserveKeys is true ? array<TKey,TValue> : list<TValue>)
      */
     public function toArray(bool $preserveKeys = true): array;
 
     /**
-     * Apply a callback to the elements of the iterator
+     * Apply a callback to the iterator's elements
      *
-     * @param callable(TValue): mixed $callback
+     * @param callable(TValue, TKey): mixed $callback
      * @return $this
      */
     public function forEach(callable $callback);
 
     /**
-     * Apply a callback to the elements of the iterator until cancelled by the
-     * callback
-     *
-     * @param callable(TValue): (true|mixed) $callback Return `true` to continue
-     * iterating over the iterator.
-     * @param bool|null $result If `$result` is provided, `false` is assigned if
-     * iteration is cancelled by the callback, otherwise `true` is assigned.
-     * @return $this
-     */
-    public function forEachWhile(callable $callback, ?bool &$result = null);
-
-    /**
-     * Get the next element with a key or property that matches a value
-     *
-     * If the current element has `$value` at `$key`, it is returned after
-     * moving the iterator forward.
+     * Get the value of the iterator's first element with a key or property
+     * equal to a given value
      *
      * @param array-key $key
      * @param mixed $value
-     * @return TValue|false `false` if no matching element is found.
+     * @return TValue|null `null` if no matching element is found.
      */
     public function nextWithValue($key, $value, bool $strict = false);
 }

--- a/src/Iterator/RecursiveFilesystemIterator.php
+++ b/src/Iterator/RecursiveFilesystemIterator.php
@@ -479,7 +479,7 @@ class RecursiveFilesystemIterator implements
             }
         }
 
-        return false;
+        return null;
     }
 
     private function getPath(string $path, FilesystemIterator $iterator): string

--- a/src/Sync/Concept/SyncDefinition.php
+++ b/src/Sync/Concept/SyncDefinition.php
@@ -344,7 +344,7 @@ abstract class SyncDefinition extends FluentInterface implements ISyncDefinition
                         $this
                             ->getFluentIterator($closure($ctx, ...$args))
                             ->nextWithValue('Id', $id);
-                    if ($entity === false) {
+                    if ($entity === null) {
                         throw new SyncEntityNotFoundException($this->Provider, $this->Entity, $id);
                     }
                     return $entity;

--- a/src/Sync/Support/SyncEntityResolver.php
+++ b/src/Sync/Support/SyncEntityResolver.php
@@ -45,12 +45,12 @@ final class SyncEntityResolver implements ISyncEntityResolver
                     ->nextWithValue($this->NameProperty, $name);
                 break;
             } catch (SyncFilterPolicyViolationException $ex) {
-                $match = false;
+                $match = null;
                 continue;
             }
         }
 
-        if ($match === false) {
+        if ($match === null) {
             $uncertainty = null;
             return null;
         }

--- a/src/Utility/Arr.php
+++ b/src/Utility/Arr.php
@@ -5,6 +5,7 @@ namespace Lkrms\Utility;
 use Lkrms\Concept\Utility;
 use Lkrms\Contract\Jsonable;
 use Lkrms\Utility\Catalog\SortTypeFlag;
+use ArrayAccess;
 use OutOfRangeException;
 use Stringable;
 
@@ -771,6 +772,27 @@ final class Arr extends Utility
             $array,
             array_fill(0, count($array), $value)
         );
+    }
+
+    /**
+     * Index an array by an identifier unique to each value
+     *
+     * @template TValue of ArrayAccess|array|object
+     *
+     * @param array<TValue> $array
+     * @param array-key $key
+     * @return array<TValue>
+     */
+    public static function toMap(array $array, $key): array
+    {
+        foreach ($array as $item) {
+            $map[
+                is_array($item) || $item instanceof ArrayAccess
+                    ? $item[$key]
+                    : $item->$key
+            ] = $item;
+        }
+        return $map ?? [];
     }
 
     /**

--- a/src/Utility/Arr.php
+++ b/src/Utility/Arr.php
@@ -197,7 +197,7 @@ final class Arr extends Utility
         bool $preserveKeys = false,
         int $flags = \SORT_REGULAR
     ): array {
-        if (!$preserveKeys) {
+        if ($preserveKeys) {
             arsort($array, $flags);
             return $array;
         }
@@ -560,8 +560,8 @@ final class Arr extends Utility
     }
 
     /**
-     * Remove whitespace from the beginning and end of each value in an array
-     * of strings and Stringables before optionally removing empty strings
+     * Remove whitespace from the beginning and end of each value in an array of
+     * strings and Stringables before optionally removing empty strings
      *
      * @template TKey of array-key
      * @template TValue of int|float|string|bool|Stringable|null
@@ -570,7 +570,7 @@ final class Arr extends Utility
      * @param string|null $characters Optionally specify characters to remove
      * instead of whitespace.
      *
-     * @return array<TKey,string>
+     * @return ($removeEmpty is false ? array<TKey,string> : list<string>)
      */
     public static function trim(
         iterable $array,
@@ -582,7 +582,10 @@ final class Arr extends Utility
                 $characters === null
                     ? trim((string) $value)
                     : trim((string) $value, $characters);
-            if ($removeEmpty && $value === '') {
+            if ($removeEmpty) {
+                if ($value !== '') {
+                    $trimmed[] = $value;
+                }
                 continue;
             }
             $trimmed[$key] = $value;
@@ -641,7 +644,7 @@ final class Arr extends Utility
     public static function toScalars(iterable $array): array
     {
         foreach ($array as $key => $value) {
-            if (!is_scalar($value)) {
+            if ($value !== null && !is_scalar($value)) {
                 if (Test::isStringable($value)) {
                     $value = (string) $value;
                 } elseif ($value instanceof Jsonable) {

--- a/src/Utility/Convert.php
+++ b/src/Utility/Convert.php
@@ -7,15 +7,10 @@ use Lkrms\Contract\IDateFormatter;
 use Lkrms\Http\Uri;
 use Lkrms\Support\Catalog\RegularExpression as Regex;
 use Lkrms\Support\DateFormatter;
-use ArrayAccess;
-use ArrayIterator;
-use Closure;
 use DateInterval;
 use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
-use Iterator;
-use IteratorIterator;
 use LogicException;
 use Stringable;
 
@@ -275,38 +270,16 @@ final class Convert extends Utility
     }
 
     /**
-     * If an iterable isn't already an array, make it one
-     *
      * @template TKey of array-key
      * @template TValue
-     *
      * @param iterable<TKey,TValue> $iterable
      * @return array<TKey,TValue>
+     * @deprecated Use {@see Get::array()} instead
+     * @codeCoverageIgnore
      */
     public static function iterableToArray(iterable $iterable, bool $preserveKeys = false): array
     {
-        return is_array($iterable) ? $iterable : iterator_to_array($iterable, $preserveKeys);
-    }
-
-    /**
-     * If an iterable isn't already an Iterator, enclose it in one
-     *
-     * @template TKey of array-key
-     * @template TValue
-     *
-     * @param iterable<TKey,TValue> $iterable
-     * @return Iterator<TKey,TValue>
-     */
-    public static function iterableToIterator(iterable $iterable): Iterator
-    {
-        if ($iterable instanceof Iterator) {
-            return $iterable;
-        }
-        if (is_array($iterable)) {
-            return new ArrayIterator($iterable);
-        }
-
-        return new IteratorIterator($iterable);
+        return Get::array($iterable, $preserveKeys);
     }
 
     /**
@@ -385,123 +358,16 @@ final class Convert extends Utility
     }
 
     /**
-     * Create a map from a list
-     *
-     * For example, to map from each array's `id` to the array itself:
-     *
-     * ```php
-     * $list = [
-     *     ['id' => 32, 'name' => 'Greta'],
-     *     ['id' => 71, 'name' => 'Terry'],
-     * ];
-     *
-     * $map = Convert::listToMap($list, 'id');
-     *
-     * print_r($map);
-     * ```
-     *
-     * ```
-     * Array
-     * (
-     *     [32] => Array
-     *         (
-     *             [id] => 32
-     *             [name] => Greta
-     *         )
-     *
-     *     [71] => Array
-     *         (
-     *             [id] => 71
-     *             [name] => Terry
-     *         )
-     *
-     * )
-     * ```
-     *
      * @template T of mixed[]|object
-     *
      * @param array<T> $list
-     * @param int|string|(Closure(T): (int|string)) $key Either the index or
-     * property name to use when retrieving keys from arrays or objects in
-     * `$list`, or a closure that returns a key for each item in `$list`.
+     * @param int|string $key
      * @return array<T>
+     * @deprecated Use {@see Arr::toMap()} instead
+     * @codeCoverageIgnore
      */
     public static function listToMap(array $list, $key): array
     {
-        return array_combine(
-            array_map(self::_keyToClosure($key), $list),
-            $list
-        );
-    }
-
-    /**
-     * Get the first item in $list where the value at $key is $value
-     *
-     * @template T0 of mixed[]|object
-     * @template T1
-     *
-     * @param iterable<array-key,T0> $list
-     * @param int|string|(Closure(T0): T1) $key Either the index or property
-     * name to use when retrieving values from arrays or objects in `$list`, or
-     * a closure that returns a value for each item in `$list`.
-     * @param T1 $value
-     * @return T0|false `false` if no item was found in `$list` with `$value` at
-     * `$key`.
-     */
-    public static function iterableToItem(iterable $list, $key, $value, bool $strict = false)
-    {
-        $list = self::iterableToIterator($list);
-        $closure = self::_keyToClosure($key);
-
-        while ($list->valid()) {
-            $item = $list->current();
-            $list->next();
-            if (($strict && ($closure($item) === $value)) ||
-                    (!$strict && ($closure($item) == $value))) {
-                return $item;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @param int|string|Closure $key
-     */
-    private static function _keyToClosure($key): Closure
-    {
-        return $key instanceof Closure
-            ? $key
-            : fn($item) => self::valueAtKey($item, $key);
-    }
-
-    /**
-     * Get the value at $key in $item, where $item is an array or object
-     *
-     * @param mixed[]|ArrayAccess|object $item
-     * @param int|string $key
-     * @return mixed
-     */
-    public static function valueAtKey($item, $key)
-    {
-        return is_array($item) || $item instanceof ArrayAccess
-            ? $item[$key]
-            : $item->$key;
-    }
-
-    /**
-     * Convert a scalar to a string
-     *
-     * @param mixed $value
-     * @return string|false Returns `false` if `$value` is not a scalar
-     */
-    public static function scalarToString($value)
-    {
-        if (is_scalar($value)) {
-            return (string) $value;
-        } else {
-            return false;
-        }
+        return Arr::toMap($list, $key);
     }
 
     /**

--- a/src/Utility/Get.php
+++ b/src/Utility/Get.php
@@ -3,6 +3,7 @@
 namespace Lkrms\Utility;
 
 use Lkrms\Concept\Utility;
+use Lkrms\Contract\Arrayable;
 use ReflectionClass;
 
 /**
@@ -10,6 +11,26 @@ use ReflectionClass;
  */
 final class Get extends Utility
 {
+    /**
+     * Resolve a value to an array
+     *
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param Arrayable<TKey,TValue>|iterable<TKey,TValue> $value
+     * @return array<TKey,TValue>
+     */
+    public static function array($value, bool $preserveKeys = false): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+        if ($value instanceof Arrayable) {
+            return $value->toArray();
+        }
+        return iterator_to_array($value, $preserveKeys);
+    }
+
     /**
      * Get the unqualified name of a class, optionally removing a suffix
      *

--- a/tests/3rdparty/Psr7Test/RequestTest.php
+++ b/tests/3rdparty/Psr7Test/RequestTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\Tests\Psr7Test;
+
+use Http\Psr7Test\RequestIntegrationTest;
+use Lkrms\Http\HttpRequest;
+
+class RequestTest extends RequestIntegrationTest
+{
+    /**
+     * @var array<string,string>
+     */
+    protected $skippedTests = [
+        'testGetRequestTargetInOriginFormNormalizesUriWithMultipleLeadingSlashesInPath' => 'Test is invalid',
+        'testMethodIsExtendable' => 'Invalid HTTP request types are rejected',
+    ];
+
+    public function createSubject()
+    {
+        return new HttpRequest('/');
+    }
+}

--- a/tests/3rdparty/Psr7Test/StreamTest.php
+++ b/tests/3rdparty/Psr7Test/StreamTest.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\Tests\Psr7Test;
+
+use Http\Psr7Test\StreamIntegrationTest;
+use Lkrms\Http\Stream;
+use Psr\Http\Message\StreamInterface;
+
+class StreamTest extends StreamIntegrationTest
+{
+    public function createStream($data)
+    {
+        if ($data instanceof StreamInterface) {
+            return $data;
+        }
+        if (is_string($data)) {
+            return Stream::fromContents($data);
+        }
+        return new Stream($data);
+    }
+}

--- a/tests/3rdparty/Psr7Test/UriTest.php
+++ b/tests/3rdparty/Psr7Test/UriTest.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\Tests\Psr7Test;
+
+use Http\Psr7Test\UriIntegrationTest;
+use Lkrms\Http\Uri;
+
+class UriTest extends UriIntegrationTest
+{
+    /**
+     * @var array<string,string>
+     */
+    protected $skippedTests = [
+        // `http://foo.com///bar` and `http://foo.com/bar` are not necessarily
+        // equivalent, and normalising URI paths by removing leading slashes
+        // without backend knowledge is not [RFC3986]-compliant
+        'testGetPathNormalizesMultipleLeadingSlashesToSingleSlashToPreventXSS' => 'Test is invalid',
+        'testPath' => 'Percent-encoded octets are normalised to uppercase per [RFC3986]',
+    ];
+
+    public function createUri($uri)
+    {
+        return (new Uri($uri, false))->normalise();
+    }
+}

--- a/tests/fixtures/Concern/Immutable/MyImmutableClass.php
+++ b/tests/fixtures/Concern/Immutable/MyImmutableClass.php
@@ -57,7 +57,7 @@ class MyImmutableClass
 
     public function __construct()
     {
-        $this->Obj = new \stdClass();
+        $this->Obj = new stdClass();
         $this->Coll = new ImmutableCollection();
     }
 

--- a/tests/unit/Concern/ImmutableTest.php
+++ b/tests/unit/Concern/ImmutableTest.php
@@ -4,6 +4,7 @@ namespace Lkrms\Tests\Concern;
 
 use Lkrms\Tests\Concern\Immutable\MyImmutableClass;
 use Lkrms\Tests\TestCase;
+use stdClass;
 
 final class ImmutableTest extends TestCase
 {
@@ -44,7 +45,7 @@ final class ImmutableTest extends TestCase
             ->with('A', 1)  // Changes to $f should be no-ops
             ->with('Obj', $obj);
 
-        $g = $f->with('Coll', $f->Coll->set('g', new \stdClass()));
+        $g = $f->with('Coll', $f->Coll->set('g', new stdClass()));
 
         $this->assertNotSame($a, $b);
         $this->assertNotEquals($a, $b);
@@ -85,7 +86,7 @@ final class ImmutableTest extends TestCase
         ];
         $A->Obj->A = 'aa';
         $A->Obj->B = 'bb';
-        $A->Coll = $A->Coll->set('g', new \stdClass());
+        $A->Coll = $A->Coll->set('g', new stdClass());
 
         $this->assertEquals($A, $g);
     }

--- a/tests/unit/Http/HttpRequestTest.php
+++ b/tests/unit/Http/HttpRequestTest.php
@@ -152,10 +152,10 @@ final class HttpRequestTest extends TestCase
     public function testMethodCaseSensitivity(): void
     {
         $r = new HttpRequest('/', 'post');
-        $this->assertSame('POST', $r->getMethod());
+        $this->assertSame('post', $r->getMethod());
 
         $r = new HttpRequest('/');
-        $this->assertSame('PUT', $r->withMethod('put')->getMethod());
+        $this->assertSame('put', $r->withMethod('put')->getMethod());
     }
 
     public function testWithUri(): void

--- a/tests/unit/Iterator/IterableIteratorTest.php
+++ b/tests/unit/Iterator/IterableIteratorTest.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\Tests\Iterator;
+
+use Lkrms\Iterator\IterableIterator;
+use Lkrms\Tests\TestCase;
+use ArrayIterator;
+use NoRewindIterator;
+
+class IterableIteratorTest extends TestCase
+{
+    /**
+     * @dataProvider nextWithValueProvider
+     *
+     * @param mixed $expected
+     * @param mixed[] $array
+     * @param array-key $key
+     * @param mixed $value
+     */
+    public function testNextWithValue(
+        $expected,
+        array $array,
+        $key,
+        $value,
+        int $runs = 1,
+        bool $strict = false
+    ): void {
+        $iterator = new IterableIterator(new NoRewindIterator(new ArrayIterator($array)));
+        while ($runs > 1) {
+            $iterator->nextWithValue($key, $value, $strict);
+            $runs--;
+        }
+        $this->assertSame($expected, $iterator->nextWithValue($key, $value, $strict));
+    }
+
+    /**
+     * @return array<array{mixed,mixed[],array-key,mixed,4?:int,5?:bool}>
+     */
+    public static function nextWithValueProvider(): array
+    {
+        $data = [
+            ['id' => 10, 'name' => 'foo'],
+            ['id' => 27, 'name' => 'bar'],
+            ['id' => 8, 'name' => 'qux'],
+            ['id' => 71, 'name' => 'qux'],
+            ['id' => 72, 'name' => 'quux'],
+            ['id' => 21, 'name' => 'quuux'],
+        ];
+
+        return [
+            [
+                ['id' => 10, 'name' => 'foo'],
+                $data,
+                'id',
+                10,
+            ],
+            [
+                null,
+                $data,
+                'id',
+                10,
+                2,
+            ],
+            [
+                ['id' => 27, 'name' => 'bar'],
+                $data,
+                'id',
+                27,
+            ],
+            [
+                ['id' => 8, 'name' => 'qux'],
+                $data,
+                'name',
+                'qux',
+            ],
+            [
+                ['id' => 71, 'name' => 'qux'],
+                $data,
+                'name',
+                'qux',
+                2,
+            ],
+            [
+                null,
+                $data,
+                'name',
+                'qux',
+                3,
+            ],
+            [
+                ['id' => 21, 'name' => 'quuux'],
+                $data,
+                'id',
+                21,
+            ],
+            [
+                null,
+                $data,
+                'id',
+                21,
+                2,
+            ],
+        ];
+    }
+}

--- a/tests/unit/Iterator/RecursiveFilesystemIteratorTest.php
+++ b/tests/unit/Iterator/RecursiveFilesystemIteratorTest.php
@@ -303,7 +303,7 @@ final class RecursiveFilesystemIteratorTest extends TestCase
         $value,
         bool $strict = false
     ): void {
-        if ($expected === null) {
+        if ($expected === false) {
             $this->expectException(LogicException::class);
         }
 
@@ -335,32 +335,32 @@ final class RecursiveFilesystemIteratorTest extends TestCase
                 true,
             ],
             [
-                false,
+                null,
                 $dir,
                 'isLink',
                 true,
                 true,
             ],
             [
-                null,
+                false,
                 $dir,
                 'isDirectory',
                 true,
             ],
             [
-                null,
+                false,
                 $dir,
                 'fileInfo',
                 true,
             ],
             [
-                null,
+                false,
                 $dir,
                 'pathInfo',
                 true,
             ],
             [
-                null,
+                false,
                 $dir,
                 'openFile',
                 true,

--- a/tests/unit/Utility/ConvertTest.php
+++ b/tests/unit/Utility/ConvertTest.php
@@ -368,52 +368,6 @@ final class ConvertTest extends TestCase
         ];
     }
 
-    public function testIterableToItem(): void
-    {
-        $data = [
-            [
-                'id' => 10,
-                'name' => 'A',
-            ],
-            [
-                'id' => 27,
-                'name' => 'B',
-            ],
-            [
-                'id' => 8,
-                'name' => 'C',
-            ],
-            [
-                'id' => 8,
-                'name' => 'D',
-            ],
-            [
-                'id' => 72,
-                'name' => 'E',
-            ],
-            [
-                'id' => 21,
-                'name' => 'F',
-            ],
-        ];
-
-        $iteratorFactory = function () use ($data) {
-            foreach ($data as $record) {
-                yield $record;
-            }
-        };
-
-        $iterator = $iteratorFactory();
-        $this->assertSame(['id' => 27, 'name' => 'B'], Convert::iterableToItem($iterator, 'id', 27));
-        $this->assertSame(['id' => 8, 'name' => 'C'], Convert::iterableToItem($iterator, 'id', 8));
-        $this->assertSame(['id' => 8, 'name' => 'D'], Convert::iterableToItem($iterator, 'id', 8));
-        $this->assertSame(['id' => 21, 'name' => 'F'], Convert::iterableToItem($iterator, 'id', 21));
-        $this->assertSame(false, Convert::iterableToItem($iterator, 'id', 8));
-
-        $iterator = $iteratorFactory();
-        $this->assertSame(['id' => 10, 'name' => 'A'], Convert::iterableToItem($iterator, 'id', 10));
-    }
-
     public function testQueryToData(): void
     {
         $this->assertSame([

--- a/tests/unit/Utility/GetTest.php
+++ b/tests/unit/Utility/GetTest.php
@@ -4,6 +4,7 @@ namespace Lkrms\Tests\Utility;
 
 use Lkrms\Tests\TestCase;
 use Lkrms\Utility\Get;
+use stdClass;
 
 final class GetTest extends TestCase
 {
@@ -131,7 +132,7 @@ final class GetTest extends TestCase
             ['array', []],
             ['array', ['foo', 'bar']],
             ['resource (closed)', $f],
-            [\stdClass::class, new \stdClass()],
+            [stdClass::class, new stdClass()],
             ['class@anonymous', new class {}],
         ];
     }


### PR DESCRIPTION
- Pass value AND key to `FluentIteratorInterface::forEach()` callbacks
- Return `null` instead of `false` when `FluentIteratorInterface::nextWithValue()` finds no matching value
- Add `Arr::toMap()`, deprecating `Convert::listToMap()`
- Add `Get::array()`, deprecating `Convert::iterableToArray()`

Remove:
- `Convert::iterableToIterator()`
- `Convert::iterableToItem()`
- `Convert::valueAtKey()`
- `Convert::scalarToString()`
- `FluentIteratorInterface::forEachWhile()` and `FluentIteratorTrait::forEachWhile()`