### PR TITLE
Consolidate repeated checks and assertions in `File`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,94 @@ The format is based on [Keep a Changelog][], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.1.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [v0.21.18] - 2023-12-29
+
+### Added
+
+- Add `File::guessIndentation()`
+- Add `File::isSeekable()`
+- Add `Str::toStream()`
+- Add `Sys::getUserId()`
+
+### Changed
+
+- Refactor `File::realpath()`
+  - Remove file descriptor handling
+  - **Throw an exception if the file doesn't exist**
+  - Resolve Phar URIs when a Phar is not running
+- Refactor `File::relativeToParent()`
+  - Require `$parentDir`
+  - Add `$fallback` (`null` by default) and return it if `$filename` does not belong to `$parentDir`
+- Refactor `File::writeCsv()`
+  - **Make `$resource` a required parameter**
+  - **Swap `$data` and `$resource` parameters**
+  - **Change return type to `void`**
+  - Remove UTF-16LE filters applied to streams provided by the caller
+  - Apply `Arr::toScalars()` to each row of data
+- Refactor `Sys::getProgramBasename()`
+  - Only remove the first matched `$suffix`
+- Rename `Stream::fromContents()` to `Stream::fromString()`
+- Rename environment variable `CONSOLE_OUTPUT` to `CONSOLE_TARGET`
+- Add optional `$null` parameter to `Arr::toScalars()`
+- Adopt `Str::lower()` and `Str::upper()` for case comparison
+- Make `File::fputcsv()` public
+
+### Fixed
+
+- Fix `File::realpath()` issue where `//../` segments in Phar URIs are not resolved correctly
+- Fix `ErrorHandler::silencePath()` issue where files and directories that start with the same name as a silenced file are inadvertently silenced
+
+## [v0.21.17] - 2023-12-25
+
+### Added
+
+- Add `Arr::flatten()`
+- Add `HttpFactory` (implements PSR-17 factory interfaces)
+
+### Changed
+
+- **Return `null` instead of `false` when `FluentIteratorInterface::nextWithValue()` finds no matching value**
+- Pass value AND key to `FluentIteratorInterface::forEach()` callback
+- In `HttpRequest`, preserve the original case of the HTTP method
+- In `HttpHeaders`, throw an exception when a header with no values is given
+- In `Uri`, do not resolve dot segments if the URI is a relative reference
+- In `Arr::toScalars()`, preserve `null` values
+- In `Arr::trim()`, remove keys from the array if removing empty values
+- Optionally preserve keys in `Arr::unique()`
+- Rename `Arr::sameValues()` to `same()`
+- Accept `iterable` where possible in `Arr` methods
+- Add `Arr::keyOffset()`, deprecating `Convert::arrayKeyToOffset()`
+- Add `Arr::toMap()`, deprecating `Convert::listToMap()`
+- Add `Arr::toScalars()`, deprecating `Convert::toScalarArray()`
+- Add `Get::array()`, deprecating `Convert::iterableToArray()`
+
+### Deprecated
+
+- Deprecate (see above):
+  - `Convert::arrayKeyToOffset()`
+  - `Convert::listToMap()`
+  - `Convert::toScalarArray()`
+  - `Convert::iterableToArray()`
+
+### Removed
+
+- Remove unused/redundant methods:
+  - `Arr::forEach()`
+  - `Convert::columnsToUnique()`
+  - `Convert::iterableToItem()`
+  - `Convert::iterableToIterator()`
+  - `Convert::scalarToString()`
+  - `Convert::stringsToUnique()`
+  - `Convert::stringsToUniqueList()`
+  - `Convert::valueAtKey()`
+  - `Convert::walkRecursive()`
+  - `FluentIteratorInterface::forEachWhile()`
+  - `FluentIteratorTrait::forEachWhile()`
+
+### Fixed
+
+- Fix bug in `Arr::sortDesc()` where keys are not preserved correctly
+
 ## [v0.21.16] - 2023-12-21
 
 ### Fixed
@@ -1159,6 +1247,8 @@ The format is based on [Keep a Changelog][], and this project adheres to
 
 - Allow `CliOption` value names to contain arbitrary characters
 
+[v0.21.18]: https://github.com/lkrms/php-util/compare/v0.21.17...v0.21.18
+[v0.21.17]: https://github.com/lkrms/php-util/compare/v0.21.16...v0.21.17
 [v0.21.16]: https://github.com/lkrms/php-util/compare/v0.21.15...v0.21.16
 [v0.21.15]: https://github.com/lkrms/php-util/compare/v0.21.14...v0.21.15
 [v0.21.14]: https://github.com/lkrms/php-util/compare/v0.21.13...v0.21.14

--- a/src/Container/Application.php
+++ b/src/Container/Application.php
@@ -428,7 +428,7 @@ class Application extends Container implements IApplication
 
         if (Cache::isLoaded()) {
             $file = Cache::getFilename();
-            if (File::is($cacheDb, $file)) {
+            if (File::same($cacheDb, $file)) {
                 return $this;
             }
             throw new LogicException(sprintf('Cache store already started: %s', $file));
@@ -455,7 +455,7 @@ class Application extends Container implements IApplication
     final public function stopCache()
     {
         if (!Cache::isLoaded() ||
-                !File::is($this->getCacheDb(false), Cache::getFilename())) {
+                !File::same($this->getCacheDb(false), Cache::getFilename())) {
             return $this;
         }
         Cache::close();
@@ -496,7 +496,7 @@ class Application extends Container implements IApplication
 
         if (Sync::isLoaded()) {
             $file = Sync::getFilename();
-            if (File::is($syncDb, $file)) {
+            if (File::same($syncDb, $file)) {
                 return $this;
             }
             throw new LogicException(sprintf('Entity store already started: %s', $file));
@@ -536,7 +536,7 @@ class Application extends Container implements IApplication
     final public function stopSync()
     {
         if (!Sync::isLoaded() ||
-                !File::is($this->getSyncDb(false), Sync::getFilename())) {
+                !File::same($this->getSyncDb(false), Sync::getFilename())) {
             return $this;
         }
         Sync::close();

--- a/src/Utility/Test.php
+++ b/src/Utility/Test.php
@@ -100,12 +100,12 @@ final class Test extends Utility
     }
 
     /**
-     * @deprecated Use {@see File::is()} instead
+     * @deprecated Use {@see File::same()} instead
      * @codeCoverageIgnore
      */
     public static function areSameFile(string $path1, string $path2): bool
     {
-        return File::is($path1, $path2);
+        return File::same($path1, $path2);
     }
 
     /**

--- a/tests/fixtures/Utility/File/broken_symlink
+++ b/tests/fixtures/Utility/File/broken_symlink
@@ -1,0 +1,1 @@
+does_not_exist

--- a/tests/fixtures/Utility/File/file_symlink
+++ b/tests/fixtures/Utility/File/file_symlink
@@ -1,0 +1,1 @@
+dir/file

--- a/tests/legacy/file
+++ b/tests/legacy/file
@@ -31,7 +31,7 @@ print_r([
     'STDOUT' => File::getStreamUri(\STDOUT),
     'STDERR' => File::getStreamUri(\STDERR),
     'areSame' => array_map(
-        function ($f) { return array_merge($f, [File::is($f[0], $f[1])]); },
+        function ($f) { return array_merge($f, [File::same($f[0], $f[1])]); },
         $compare
     )
 ]);

--- a/tests/unit/Utility/FileTest.php
+++ b/tests/unit/Utility/FileTest.php
@@ -12,6 +12,37 @@ use Lkrms\Utility\Str;
 final class FileTest extends TestCase
 {
     /**
+     * @dataProvider getEolProvider
+     */
+    public function testGetEol(?string $expected, string $content): void
+    {
+        $stream = Str::toStream($content);
+        $this->assertSame($expected, File::getEol($stream));
+    }
+
+    /**
+     * @return array<array{string|null,string}>
+     */
+    public static function getEolProvider(): array
+    {
+        return [
+            [null, ''],
+            [null, 'x'],
+            ["\r\n", "\r\n"],
+            ["\r\n", "x\r\n"],
+            ["\r\n", "x\r\nx"],
+            ["\n", "\n"],
+            ["\n", "x\n"],
+            ["\n", "x\nx"],
+            ["\r", "\r"],
+            ["\r", "x\r"],
+            ["\r", "x\rx"],
+            ["\n", "x\rx\n"],
+            ["\r\n", "x\rx\r\n"],
+        ];
+    }
+
+    /**
      * Derived from VS Code's textModel tests
      *
      * @dataProvider guessIndentationProvider
@@ -960,5 +991,14 @@ final class FileTest extends TestCase
         $this->assertTrue(File::isAbsolute($path));
         $this->assertDirectoryExists($dir);
         $this->assertIsWritable($dir);
+    }
+
+    public function testSame(): void
+    {
+        $path = $this->getFixturesPath(__CLASS__);
+        $this->assertTrue(File::same("$path/dir/file", "$path/dir/file"));
+        $this->assertTrue(File::same("$path/dir/file", "$path/file_symlink"));
+        $this->assertFalse(File::same("$path/dir/file", "$path/exists"));
+        $this->assertFalse(File::same("$path/dir/file", "$path/broken_symlink"));
     }
 }

--- a/tools/apigen/composer.lock
+++ b/tools/apigen/composer.lock
@@ -1050,16 +1050,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.24.4",
+            "version": "1.24.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "6bd0c26f3786cd9b7c359675cb789e35a8e07496"
+                "reference": "fedf211ff14ec8381c9bf5714e33a7a552dd1acc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/6bd0c26f3786cd9b7c359675cb789e35a8e07496",
-                "reference": "6bd0c26f3786cd9b7c359675cb789e35a8e07496",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fedf211ff14ec8381c9bf5714e33a7a552dd1acc",
+                "reference": "fedf211ff14ec8381c9bf5714e33a7a552dd1acc",
                 "shasum": ""
             },
             "require": {
@@ -1091,9 +1091,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.4"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.5"
             },
-            "time": "2023-11-26T18:29:22+00:00"
+            "time": "2023-12-16T09:33:33+00:00"
         },
         {
             "name": "psr/container",
@@ -1526,21 +1526,21 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.4.0",
+            "version": "v3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "b3313c2dbffaf71c8de2934e2ea56ed2291a3838"
+                "reference": "fe07cbc8d837f60caf7018068e350cc5163681a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/b3313c2dbffaf71c8de2934e2ea56ed2291a3838",
-                "reference": "b3313c2dbffaf71c8de2934e2ea56ed2291a3838",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/fe07cbc8d837f60caf7018068e350cc5163681a0",
+                "reference": "fe07cbc8d837f60caf7018068e350cc5163681a0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
-                "psr/container": "^2.0"
+                "psr/container": "^1.1|^2.0"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
@@ -1588,7 +1588,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.4.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.4.1"
             },
             "funding": [
                 {
@@ -1604,7 +1604,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-30T20:28:31+00:00"
+            "time": "2023-12-26T14:02:43+00:00"
         },
         {
             "name": "symfony/string",

--- a/tools/changelog/composer.lock
+++ b/tools/changelog/composer.lock
@@ -52,16 +52,16 @@
         },
         {
             "name": "lkrms/util",
-            "version": "v0.21.12",
+            "version": "v0.21.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lkrms/php-util.git",
-                "reference": "36770b8f1170cbde44b82ef7d892f7fae48db0ba"
+                "reference": "b4a310435b637621db2f174135cad57d5aa91eb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lkrms/php-util/zipball/36770b8f1170cbde44b82ef7d892f7fae48db0ba",
-                "reference": "36770b8f1170cbde44b82ef7d892f7fae48db0ba",
+                "url": "https://api.github.com/repos/lkrms/php-util/zipball/b4a310435b637621db2f174135cad57d5aa91eb1",
+                "reference": "b4a310435b637621db2f174135cad57d5aa91eb1",
                 "shasum": ""
             },
             "require": {
@@ -70,6 +70,7 @@
                 "php": ">=7.4",
                 "psr/container": "^2",
                 "psr/event-dispatcher": "^1",
+                "psr/http-factory": "^1",
                 "psr/http-message": "^1.1 || ^2",
                 "psr/log": "^1"
             },
@@ -82,6 +83,7 @@
                 "clue/phar-composer": "^1",
                 "firebase/php-jwt": "^6",
                 "league/oauth2-client": "^2",
+                "php-http/psr7-integration-tests": "^1.3",
                 "phpstan/extension-installer": "^1",
                 "phpstan/phpstan": "^1",
                 "phpstan/phpstan-deprecation-rules": "^1",
@@ -117,9 +119,9 @@
             "description": "A lightweight PHP toolkit for expressive backend/CLI apps",
             "support": {
                 "issues": "https://github.com/lkrms/php-util/issues",
-                "source": "https://github.com/lkrms/php-util/tree/v0.21.12"
+                "source": "https://github.com/lkrms/php-util/tree/v0.21.18"
             },
-            "time": "2023-12-12T15:24:37+00:00"
+            "time": "2023-12-29T04:39:34+00:00"
         },
         {
             "name": "psr/container",
@@ -223,6 +225,61 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
+            },
+            "time": "2023-04-10T20:10:41+00:00"
         },
         {
             "name": "psr/http-message",

--- a/tools/mockoon-cli/package-lock.json
+++ b/tools/mockoon-cli/package-lock.json
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.6.tgz",
-      "integrity": "sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==",
+      "version": "7.23.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.7.tgz",
+      "integrity": "sha512-w06OXVOFso7LcbzMiDGt+3X7Rh7Ho8MmgPoWU3rarH+8upf+wSU/grlGbWzQyr3DkdN6ZeuMFjpdwW0Q+HxobA==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -346,9 +346,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.10.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
-      "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.6.tgz",
+      "integrity": "sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -371,9 +371,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1055,9 +1055,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
+      "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -1952,9 +1952,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",

--- a/tools/php-cs-fixer/composer.lock
+++ b/tools/php-cs-fixer/composer.lock
@@ -227,16 +227,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.41.1",
+            "version": "v3.45.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "8b6ae8dcbaf23f09680643ab832a4a3a260265f6"
+                "reference": "c0daa33cb2533cd73f48dde1c70c2afa3e7953b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/8b6ae8dcbaf23f09680643ab832a4a3a260265f6",
-                "reference": "8b6ae8dcbaf23f09680643ab832a4a3a260265f6",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/c0daa33cb2533cd73f48dde1c70c2afa3e7953b5",
+                "reference": "c0daa33cb2533cd73f48dde1c70c2afa3e7953b5",
                 "shasum": ""
             },
             "require": {
@@ -266,8 +266,7 @@
                 "php-cs-fixer/accessible-object": "^1.1",
                 "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.4",
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.4",
-                "phpunit/phpunit": "^9.6",
-                "symfony/phpunit-bridge": "^6.3.8 || ^7.0",
+                "phpunit/phpunit": "^9.6 || ^10.5.5",
                 "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
             },
             "suggest": {
@@ -306,7 +305,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.41.1"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.45.0"
             },
             "funding": [
                 {
@@ -314,7 +313,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-10T19:59:27+00:00"
+            "time": "2023-12-30T02:07:07+00:00"
         },
         {
             "name": "psr/container",
@@ -471,16 +470,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "5.0.3",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b"
+                "reference": "fbf413a49e54f6b9b17e12d900ac7f6101591b7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
-                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/fbf413a49e54f6b9b17e12d900ac7f6101591b7f",
+                "reference": "fbf413a49e54f6b9b17e12d900ac7f6101591b7f",
                 "shasum": ""
             },
             "require": {
@@ -493,7 +492,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -526,7 +525,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.0"
             },
             "funding": [
                 {
@@ -534,7 +533,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-01T07:48:21+00:00"
+            "time": "2023-12-22T10:55:06+00:00"
         },
         {
             "name": "symfony/console",
@@ -1602,21 +1601,21 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.4.0",
+            "version": "v3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "b3313c2dbffaf71c8de2934e2ea56ed2291a3838"
+                "reference": "fe07cbc8d837f60caf7018068e350cc5163681a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/b3313c2dbffaf71c8de2934e2ea56ed2291a3838",
-                "reference": "b3313c2dbffaf71c8de2934e2ea56ed2291a3838",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/fe07cbc8d837f60caf7018068e350cc5163681a0",
+                "reference": "fe07cbc8d837f60caf7018068e350cc5163681a0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
-                "psr/container": "^2.0"
+                "psr/container": "^1.1|^2.0"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
@@ -1664,7 +1663,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.4.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.4.1"
             },
             "funding": [
                 {
@@ -1680,7 +1679,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-30T20:28:31+00:00"
+            "time": "2023-12-26T14:02:43+00:00"
         },
         {
             "name": "symfony/stopwatch",

--- a/tools/pretty-php/composer.json
+++ b/tools/pretty-php/composer.json
@@ -3,7 +3,7 @@
         "php": "^8.1"
     },
     "require-dev": {
-        "lkrms/pretty-php": "^0.4.44"
+        "lkrms/pretty-php": "^0.4.45"
     },
     "config": {
         "platform": {

--- a/tools/pretty-php/composer.lock
+++ b/tools/pretty-php/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9fe1962f45d3e566abfbd56e5518c4c8",
+    "content-hash": "7ba335f0370a13dcf767d17b5d229a11",
     "packages": [],
     "packages-dev": [
         {
@@ -52,16 +52,16 @@
         },
         {
             "name": "lkrms/pretty-php",
-            "version": "v0.4.44",
+            "version": "v0.4.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lkrms/pretty-php.git",
-                "reference": "25fde317a145004f95016873cc7eabaf8a12697a"
+                "reference": "578e402f76c3d965aca9dc2131ed8bd4c2488d3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lkrms/pretty-php/zipball/25fde317a145004f95016873cc7eabaf8a12697a",
-                "reference": "25fde317a145004f95016873cc7eabaf8a12697a",
+                "url": "https://api.github.com/repos/lkrms/pretty-php/zipball/578e402f76c3d965aca9dc2131ed8bd4c2488d3e",
+                "reference": "578e402f76c3d965aca9dc2131ed8bd4c2488d3e",
                 "shasum": ""
             },
             "require": {
@@ -69,7 +69,7 @@
                 "ext-json": "*",
                 "ext-mbstring": "*",
                 "ext-tokenizer": "*",
-                "lkrms/util": "^0.21.16",
+                "lkrms/util": "^0.21.18",
                 "php": ">=7.4",
                 "sebastian/diff": "^4 || ^5"
             },
@@ -106,20 +106,20 @@
                 "issues": "https://github.com/lkrms/pretty-php/issues",
                 "source": "https://github.com/lkrms/pretty-php"
             },
-            "time": "2023-12-21T14:50:36+00:00"
+            "time": "2023-12-29T05:37:34+00:00"
         },
         {
             "name": "lkrms/util",
-            "version": "v0.21.16",
+            "version": "v0.21.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lkrms/php-util.git",
-                "reference": "789bbf0a7e61a9c60de61bd31552a6b11fbda6a8"
+                "reference": "b4a310435b637621db2f174135cad57d5aa91eb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lkrms/php-util/zipball/789bbf0a7e61a9c60de61bd31552a6b11fbda6a8",
-                "reference": "789bbf0a7e61a9c60de61bd31552a6b11fbda6a8",
+                "url": "https://api.github.com/repos/lkrms/php-util/zipball/b4a310435b637621db2f174135cad57d5aa91eb1",
+                "reference": "b4a310435b637621db2f174135cad57d5aa91eb1",
                 "shasum": ""
             },
             "require": {
@@ -128,6 +128,7 @@
                 "php": ">=7.4",
                 "psr/container": "^2",
                 "psr/event-dispatcher": "^1",
+                "psr/http-factory": "^1",
                 "psr/http-message": "^1.1 || ^2",
                 "psr/log": "^1"
             },
@@ -140,6 +141,7 @@
                 "clue/phar-composer": "^1",
                 "firebase/php-jwt": "^6",
                 "league/oauth2-client": "^2",
+                "php-http/psr7-integration-tests": "^1.3",
                 "phpstan/extension-installer": "^1",
                 "phpstan/phpstan": "^1",
                 "phpstan/phpstan-deprecation-rules": "^1",
@@ -175,9 +177,9 @@
             "description": "A lightweight PHP toolkit for expressive backend/CLI apps",
             "support": {
                 "issues": "https://github.com/lkrms/php-util/issues",
-                "source": "https://github.com/lkrms/php-util/tree/v0.21.16"
+                "source": "https://github.com/lkrms/php-util/tree/v0.21.18"
             },
-            "time": "2023-12-21T12:06:07+00:00"
+            "time": "2023-12-29T04:39:34+00:00"
         },
         {
             "name": "psr/container",
@@ -281,6 +283,61 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
+            },
+            "time": "2023-04-10T20:10:41+00:00"
         },
         {
             "name": "psr/http-message",
@@ -387,16 +444,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "5.0.3",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b"
+                "reference": "fbf413a49e54f6b9b17e12d900ac7f6101591b7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
-                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/fbf413a49e54f6b9b17e12d900ac7f6101591b7f",
+                "reference": "fbf413a49e54f6b9b17e12d900ac7f6101591b7f",
                 "shasum": ""
             },
             "require": {
@@ -409,7 +466,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -442,7 +499,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.0"
             },
             "funding": [
                 {
@@ -450,7 +507,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-01T07:48:21+00:00"
+            "time": "2023-12-22T10:55:06+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
Also:
- Allow filenames to be passed to `File::stat()`, not just streams
- Rename `File::is()` to `File::same()`
- Fix an issue where `File::same()` returns `true` for files with the same inode number on different devices
- Add tests for `File::same()` and `File::getEol()`
- Update `CHANGELOG.md`, `tools`