### PR TITLE
Cli: simplify and improve consistency of help output

### DIFF
--- a/src/Cli/Exception/CliInvalidArgumentsException.php
+++ b/src/Cli/Exception/CliInvalidArgumentsException.php
@@ -12,5 +12,6 @@ class CliInvalidArgumentsException extends MultipleErrorException
     public function __construct(string ...$errors)
     {
         parent::__construct('Invalid arguments', ...$errors);
+        $this->ExitStatus = 1;
     }
 }

--- a/src/Console/ConsoleWriter.php
+++ b/src/Console/ConsoleWriter.php
@@ -424,6 +424,27 @@ final class ConsoleWriter implements ReceivesFacade
      */
     public function getWidth($level = Level::INFO): ?int
     {
+        return $this->maybeGetTtyTarget($level)->getWidth();
+    }
+
+    /**
+     * Get an output formatter for a registered target
+     *
+     * Returns {@see Target::getFormatter()} from the same target as
+     * {@see ConsoleWriter::getWidth()}.
+     *
+     * @param Level::* $level
+     */
+    public function getFormatter($level = Level::INFO): Formatter
+    {
+        return $this->maybeGetTtyTarget($level)->getFormatter();
+    }
+
+    /**
+     * @param Level::* $level
+     */
+    private function maybeGetTtyTarget($level): TargetStream
+    {
         /** @var Target[] */
         $targets = $this->TtyTargetsByLevel[$level]
             ?? $this->StdioTargetsByLevel[$level]
@@ -431,14 +452,14 @@ final class ConsoleWriter implements ReceivesFacade
             ?? [];
 
         $target = reset($targets);
-        if (!$target) {
+        if (!$target || !($target instanceof TargetStream)) {
             $target = $this->getStderrTarget();
             if (!$target->isTty()) {
-                $target = $this->getStdoutTarget();
+                return $this->getStdoutTarget();
             }
         }
 
-        return $target->getWidth();
+        return $target;
     }
 
     /**

--- a/src/Console/Contract/ConsoleFormatterFactory.php
+++ b/src/Console/Contract/ConsoleFormatterFactory.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\Console\Contract;
+
+use Lkrms\Console\ConsoleFormatter as Formatter;
+
+interface ConsoleFormatterFactory
+{
+    /**
+     * Get a console output formatter
+     */
+    public static function getFormatter(): Formatter;
+}

--- a/src/Console/Contract/ConsoleTargetInterface.php
+++ b/src/Console/Contract/ConsoleTargetInterface.php
@@ -3,7 +3,7 @@
 namespace Lkrms\Console\Contract;
 
 use Lkrms\Console\Catalog\ConsoleLevel as Level;
-use Lkrms\Console\ConsoleFormatter;
+use Lkrms\Console\ConsoleFormatter as Formatter;
 
 /**
  * A console output target
@@ -15,7 +15,7 @@ interface ConsoleTargetInterface
     /**
      * Get an output formatter for the target
      */
-    public function getFormatter(): ConsoleFormatter;
+    public function getFormatter(): Formatter;
 
     /**
      * Get the width of the target in columns

--- a/src/Console/Support/ConsoleLoopbackFormat.php
+++ b/src/Console/Support/ConsoleLoopbackFormat.php
@@ -4,14 +4,19 @@ namespace Lkrms\Console\Support;
 
 use Lkrms\Console\Catalog\ConsoleTag as Tag;
 use Lkrms\Console\Contract\ConsoleFormatInterface;
+use Lkrms\Console\Contract\ConsoleFormatterFactory;
 use Lkrms\Console\Contract\ConsoleTagFormatFactory;
 use Lkrms\Console\Support\ConsoleTagAttributes as TagAttributes;
 use Lkrms\Console\Support\ConsoleTagFormats as TagFormats;
+use Lkrms\Console\ConsoleFormatter as Formatter;
 
 /**
  * Reapplies the output's original inline formatting tags
  */
-final class ConsoleLoopbackFormat implements ConsoleFormatInterface, ConsoleTagFormatFactory
+final class ConsoleLoopbackFormat implements
+    ConsoleFormatInterface,
+    ConsoleFormatterFactory,
+    ConsoleTagFormatFactory
 {
     private string $Before;
 
@@ -64,9 +69,17 @@ final class ConsoleLoopbackFormat implements ConsoleFormatInterface, ConsoleTagF
     /**
      * @inheritDoc
      */
+    public static function getFormatter(): Formatter
+    {
+        return new Formatter(self::getTagFormats());
+    }
+
+    /**
+     * @inheritDoc
+     */
     public static function getTagFormats(): TagFormats
     {
-        return (new TagFormats())
+        return (new TagFormats(false))
             ->set(Tag::HEADING, new self('***', '***'))
             ->set(Tag::BOLD, new self('**', '**'))
             ->set(Tag::ITALIC, new self('*', '*'))

--- a/src/Console/Support/ConsoleManPageFormat.php
+++ b/src/Console/Support/ConsoleManPageFormat.php
@@ -4,14 +4,19 @@ namespace Lkrms\Console\Support;
 
 use Lkrms\Console\Catalog\ConsoleTag as Tag;
 use Lkrms\Console\Contract\ConsoleFormatInterface;
+use Lkrms\Console\Contract\ConsoleFormatterFactory;
 use Lkrms\Console\Contract\ConsoleTagFormatFactory;
 use Lkrms\Console\Support\ConsoleTagAttributes as TagAttributes;
 use Lkrms\Console\Support\ConsoleTagFormats as TagFormats;
+use Lkrms\Console\ConsoleFormatter as Formatter;
 
 /**
  * Applies Markdown formatting with man page extensions to console output
  */
-final class ConsoleManPageFormat implements ConsoleFormatInterface, ConsoleTagFormatFactory
+final class ConsoleManPageFormat implements
+    ConsoleFormatInterface,
+    ConsoleFormatterFactory,
+    ConsoleTagFormatFactory
 {
     private string $Before;
 
@@ -67,9 +72,17 @@ final class ConsoleManPageFormat implements ConsoleFormatInterface, ConsoleTagFo
     /**
      * @inheritDoc
      */
+    public static function getFormatter(): Formatter
+    {
+        return new Formatter(self::getTagFormats());
+    }
+
+    /**
+     * @inheritDoc
+     */
     public static function getTagFormats(): TagFormats
     {
-        return (new TagFormats())
+        return (new TagFormats(false, true))
             ->set(Tag::HEADING, new self('***', '***'))
             ->set(Tag::BOLD, new self('**', '**'))
             ->set(Tag::ITALIC, new self('*', '*'))

--- a/src/Console/Support/ConsoleTagAttributes.php
+++ b/src/Console/Support/ConsoleTagAttributes.php
@@ -25,6 +25,20 @@ final class ConsoleTagAttributes
     public string $OpenTag;
 
     /**
+     * Tag depth
+     *
+     * @readonly
+     */
+    public int $Depth;
+
+    /**
+     * True if the tag has nested tags
+     *
+     * @readonly
+     */
+    public ?bool $HasChildren;
+
+    /**
      * Horizontal whitespace before the tag (fenced code blocks only)
      *
      * @readonly
@@ -44,11 +58,15 @@ final class ConsoleTagAttributes
     public function __construct(
         int $tag,
         string $openTag,
+        int $depth = 0,
+        ?bool $hasChildren = null,
         ?string $indent = null,
         ?string $infoString = null
     ) {
         $this->Tag = $tag;
         $this->OpenTag = $openTag;
+        $this->Depth = $depth;
+        $this->HasChildren = $hasChildren;
         $this->Indent = $indent;
         $this->InfoString = $infoString;
     }

--- a/src/Console/Support/ConsoleTagFormats.php
+++ b/src/Console/Support/ConsoleTagFormats.php
@@ -2,6 +2,7 @@
 
 namespace Lkrms\Console\Support;
 
+use Lkrms\Concern\Immutable;
 use Lkrms\Console\Catalog\ConsoleTag as Tag;
 use Lkrms\Console\Contract\ConsoleFormatInterface as Format;
 use Lkrms\Console\Support\ConsoleTagAttributes as TagAttributes;
@@ -11,17 +12,60 @@ use Lkrms\Console\Support\ConsoleTagAttributes as TagAttributes;
  */
 final class ConsoleTagFormats
 {
+    use Immutable;
+
     /**
      * @var array<Tag::*,Format>
      */
     private array $Formats = [];
 
+    private bool $Unescape;
+
+    private bool $WrapAfterApply;
+
     private Format $FallbackFormat;
 
-    public function __construct(?Format $fallbackFormat = null)
-    {
+    public function __construct(
+        bool $unescape = true,
+        bool $wrapAfterApply = false,
+        ?Format $fallbackFormat = null
+    ) {
+        $this->Unescape = $unescape;
+        $this->WrapAfterApply = $wrapAfterApply;
         $this->FallbackFormat = $fallbackFormat
             ?: ConsoleFormat::getDefaultFormat();
+    }
+
+    /**
+     * @return static
+     */
+    public function withUnescape(bool $value = true)
+    {
+        return $this->withPropertyValue('Unescape', $value);
+    }
+
+    /**
+     * @return static
+     */
+    public function withWrapAfterApply(bool $value = true)
+    {
+        return $this->withPropertyValue('WrapAfterApply', $value);
+    }
+
+    /**
+     * True if text should be unescaped for the target
+     */
+    public function getUnescape(): bool
+    {
+        return $this->Unescape;
+    }
+
+    /**
+     * True if text should be wrapped after formatting
+     */
+    public function getWrapAfterApply(): bool
+    {
+        return $this->WrapAfterApply;
     }
 
     /**

--- a/src/Console/Target/MockTarget.php
+++ b/src/Console/Target/MockTarget.php
@@ -4,7 +4,7 @@ namespace Lkrms\Console\Target;
 
 use Lkrms\Console\Catalog\ConsoleLevel as Level;
 use Lkrms\Console\Contract\ConsoleTargetStreamInterface;
-use Lkrms\Console\ConsoleFormatter;
+use Lkrms\Console\ConsoleFormatter as Formatter;
 use Lkrms\Utility\File;
 
 /**
@@ -25,7 +25,7 @@ final class MockTarget implements ConsoleTargetStreamInterface
      */
     private $Stream;
 
-    private ConsoleFormatter $Formatter;
+    private Formatter $Formatter;
 
     /**
      * @var array<array{Level::*,string,2?:array<string,mixed>}>
@@ -42,7 +42,7 @@ final class MockTarget implements ConsoleTargetStreamInterface
         bool $isStderr = true,
         bool $isTty = true,
         ?int $width = 80,
-        ?ConsoleFormatter $formatter = null
+        ?Formatter $formatter = null
     ) {
         if ($stream) {
             stream_set_write_buffer($stream, 0);
@@ -54,7 +54,7 @@ final class MockTarget implements ConsoleTargetStreamInterface
         $this->Width = $width;
         $this->Stream = $stream;
         $this->Formatter = $formatter
-            ?: new ConsoleFormatter(null, null, fn(): ?int => $this->getWidth());
+            ?: new Formatter(null, null, fn(): ?int => $this->getWidth());
     }
 
     /**
@@ -84,7 +84,7 @@ final class MockTarget implements ConsoleTargetStreamInterface
     /**
      * @inheritDoc
      */
-    public function getFormatter(): ConsoleFormatter
+    public function getFormatter(): Formatter
     {
         return clone $this->Formatter;
     }

--- a/src/Facade/Console.php
+++ b/src/Facade/Console.php
@@ -9,6 +9,7 @@ use Lkrms\Console\Catalog\ConsoleMessageType as MessageType;
 use Lkrms\Console\Catalog\ConsoleTargetTypeFlag as TargetTypeFlag;
 use Lkrms\Console\Contract\ConsoleTargetInterface as Target;
 use Lkrms\Console\Contract\ConsoleTargetStreamInterface as TargetStream;
+use Lkrms\Console\ConsoleFormatter as Formatter;
 use Lkrms\Console\ConsoleWriter;
 use Throwable;
 
@@ -27,6 +28,7 @@ use Throwable;
  * @method static ConsoleWriter errorOnce(string $msg1, ?string $msg2 = null, ?Throwable $ex = null, bool $count = true) Print " !! $msg1 $msg2" with level ERROR once per run
  * @method static ConsoleWriter exception(Throwable $exception, Level::* $messageLevel = Level::ERROR, Level::*|null $stackTraceLevel = Level::DEBUG) Report an uncaught exception (see {@see ConsoleWriter::exception()})
  * @method static int getErrors() Get the number of errors reported so far
+ * @method static Formatter getFormatter(Level::* $level = Level::INFO) Get an output formatter for a registered target (see {@see ConsoleWriter::getFormatter()})
  * @method static TargetStream getStderrTarget() Get a target for STDERR, creating it if necessary
  * @method static TargetStream getStdoutTarget() Get a target for STDOUT, creating it if necessary
  * @method static Target[] getTargets() Get a list of registered output targets


### PR DESCRIPTION
- Include syntax when wrapping Markdown and man page output
- Wrap Markdown and man page output to 80 columns
- Always wrap synopses
- Add `Console::getFormatter()`
- In `ConsoleFormatter::formatTags()`:
  - Fix inconsistent Markdown output by wrapping text after formatting if `ConsoleTagFormats::getWrapAfterApply()` returns `true` and honouring `ConsoleTagFormats::getUnescape()`
  - Remove `$unescape` parameter
  - Add optional `$unformat` parameter
  - Add tests and fix multiple bugs
- Add `ConsoleFormatterFactory` and add static `getFormatter()` methods to `ConsoleLoopbackFormat`, `ConsoleManPageFormat`, `ConsoleMarkdownFormat`