### PR TITLE
Improve EOL sequence consistency in Console and Cli

### DIFF
--- a/src/Cli/CliApplication.php
+++ b/src/Cli/CliApplication.php
@@ -456,11 +456,12 @@ class CliApplication extends Application implements ICliApplication
                 $formats = ConsoleManPageFormat::getTagFormats();
                 $progName = $this->getProgramName();
                 printf(
-                    "%% %s(%d) %s | %s\n\n",
+                    '%% %s(%d) %s | %s%s',
                     Str::upper(str_replace(' ', '-', trim("$progName $name"))),
                     (int) ($args[0] ?? '1'),
                     $args[1] ?? Package::version(),
                     $args[2] ?? (($name === '' ? $progName : Package::name()) . ' Documentation'),
+                    \PHP_EOL . \PHP_EOL,
                 );
                 break;
 
@@ -477,6 +478,7 @@ class CliApplication extends Application implements ICliApplication
 
         $usage = $this->getHelp($name, $node, $style);
         $usage = $formatter->formatTags($usage);
-        printf("%s\n", str_replace('\ ', ' ', $usage));
+        $usage = Str::eolToNative($usage);
+        printf('%s%s', str_replace('\ ', ' ', $usage), \PHP_EOL);
     }
 }

--- a/src/Cli/CliOption.php
+++ b/src/Cli/CliOption.php
@@ -749,7 +749,7 @@ final class CliOption implements Buildable, HasJsonSchema, IImmutable, IReadable
         if ($desc === '') {
             return null;
         }
-        if ($withFullStop && $desc[-1] !== '.') {
+        if ($withFullStop && strpbrk($desc[-1], '.!?') === false) {
             $desc .= '.';
         }
         return Pcre::replace('/\s+/', ' ', $desc);

--- a/src/Cli/Support/CliHelpStyle.php
+++ b/src/Cli/Support/CliHelpStyle.php
@@ -208,22 +208,11 @@ final class CliHelpStyle
 
             if ($this->Target === CliHelpTarget::TTY) {
                 $content = str_replace("\n", "\n    ", $content);
-                $help .= <<<EOF
-                    ## $heading
-                        $content
-
-
-                    EOF;
+                $help .= "## $heading\n    $content\n\n";
                 continue;
             }
 
-            $help .= <<<EOF
-                ## $heading
-
-                $content
-
-
-                EOF;
+            $help .= "## $heading\n\n$content\n\n";
         }
 
         return Pcre::replace('/^\h++$/m', '', rtrim($help));

--- a/src/Utility/Json.php
+++ b/src/Utility/Json.php
@@ -40,10 +40,9 @@ final class Json extends Utility
      */
     public static function prettyPrint($value, int $flags = 0): string
     {
-        $json = json_encode($value, self::ENCODE_FLAGS | \JSON_PRETTY_PRINT | $flags);
-        return \PHP_EOL === "\n"
-            ? $json
-            : str_replace("\n", \PHP_EOL, $json);
+        return Str::eolToNative(
+            json_encode($value, self::ENCODE_FLAGS | \JSON_PRETTY_PRINT | $flags)
+        );
     }
 
     /**

--- a/src/Utility/Str.php
+++ b/src/Utility/Str.php
@@ -60,19 +60,55 @@ final class Str extends Utility
     /**
      * Apply an end-of-line sequence to a string
      */
-    public static function setEol(string $string, string $eol = "\n", ?string $currentEol = null): string
+    public static function setEol(string $string, string $eol = "\n"): string
     {
-        if ($currentEol === null) {
-            $currentEol = Get::eol($string);
-            // No end-of-line sequence = no line breaks = nothing to do
-            if ($currentEol === null) {
-                return $string;
-            }
+        switch ($eol) {
+            case "\n":
+                return str_replace(["\r\n", "\r"], $eol, $string);
+
+            case "\r":
+                return str_replace(["\r\n", "\n"], $eol, $string);
+
+            case "\r\n":
+                return str_replace(["\r\n", "\r", "\n"], ["\n", "\n", $eol], $string);
+
+            default:
+                return str_replace("\n", $eol, self::setEol($string));
         }
-        if ($eol === $currentEol) {
-            return $string;
-        }
-        return str_replace($currentEol, $eol, $string);
+    }
+
+    /**
+     * Replace newlines in a string with native end-of-line sequences
+     *
+     * @template T of string|null
+     *
+     * @param T $string
+     * @return T
+     */
+    public static function eolToNative(?string $string): ?string
+    {
+        return $string === null
+            ? null
+            : (\PHP_EOL === "\n"
+                ? $string
+                : str_replace("\n", \PHP_EOL, $string));
+    }
+
+    /**
+     * Replace native end-of-line sequences in a string with newlines
+     *
+     * @template T of string|null
+     *
+     * @param T $string
+     * @return T
+     */
+    public static function eolFromNative(?string $string): ?string
+    {
+        return $string === null
+            ? null
+            : (\PHP_EOL === "\n"
+                ? $string
+                : str_replace(\PHP_EOL, "\n", $string));
     }
 
     /**

--- a/tests/unit/Cli/CliApplicationTest.php
+++ b/tests/unit/Cli/CliApplicationTest.php
@@ -57,7 +57,7 @@ final class CliApplicationTest extends TestCase
         $_SERVER['argv'] = ['app.php'];
         $app = $this->App->oneCommand(TestOptions::class);
         $this->assertSame(1, $app->run()->getLastExitStatus());
-        $this->assertSame([
+        $this->assertSameConsoleMessages([
             [Level::ERROR, 'Error: --start required'],
             [Level::INFO, <<<'EOF'
 
@@ -73,7 +73,7 @@ final class CliApplicationTest extends TestCase
         $_SERVER['argv'] = ['app.php', '--help'];
         $app = $this->App->oneCommand(TestOptions::class);
         $this->assertSame(0, $app->run()->getLastExitStatus());
-        $this->assertSame([
+        $this->assertSameConsoleMessages([
             [Level::INFO, <<<'EOF'
                 NAME
                     app - Test CliCommand options

--- a/tests/unit/Console/ConsoleFormatterTest.php
+++ b/tests/unit/Console/ConsoleFormatterTest.php
@@ -7,6 +7,7 @@ use Lkrms\Console\Support\ConsoleManPageFormat;
 use Lkrms\Console\Support\ConsoleMarkdownFormat;
 use Lkrms\Console\ConsoleFormatter as Formatter;
 use Lkrms\Tests\TestCase;
+use Lkrms\Utility\Str;
 
 final class ConsoleFormatterTest extends TestCase
 {
@@ -24,7 +25,16 @@ final class ConsoleFormatterTest extends TestCase
         bool $unformat = false,
         string $break = "\n"
     ): void {
-        $this->assertSame($expected, $formatter->formatTags($string, $unwrap, $wrapToWidth, $unformat, $break));
+        $this->assertSame(
+            Str::eolFromNative($expected),
+            $formatter->formatTags(
+                $string,
+                $unwrap,
+                $wrapToWidth,
+                $unformat,
+                $break,
+            )
+        );
     }
 
     /**

--- a/tests/unit/Support/PhpDoc/PhpDocTest.php
+++ b/tests/unit/Support/PhpDoc/PhpDocTest.php
@@ -6,6 +6,7 @@ use Lkrms\Exception\InvalidArgumentException;
 use Lkrms\Support\Catalog\RegularExpression as Regex;
 use Lkrms\Support\PhpDoc\PhpDoc;
 use Lkrms\Tests\TestCase;
+use Lkrms\Utility\Str;
 
 final class PhpDocTest extends TestCase
 {
@@ -80,7 +81,7 @@ final class PhpDocTest extends TestCase
             ```php
             // code here
             ```
-            EOF, $this->eolToNative($phpDoc->Description));
+            EOF, Str::eolToNative($phpDoc->Description));
         $this->assertSame([
             '@param $arg1 Description from ClassC (untyped)',
             '@param string[] $arg3',
@@ -141,7 +142,7 @@ final class PhpDocTest extends TestCase
     ): void {
         $phpDoc = new PhpDoc($docBlock);
         $this->assertSame($summary, $phpDoc->Summary);
-        $this->assertSame($description, $this->eolToNative($phpDoc->Description));
+        $this->assertSame($description, Str::eolToNative($phpDoc->Description));
         $this->assertCount(count($varKeys), $phpDoc->Vars);
         foreach ($varKeys as $i => $key) {
             $this->assertArrayHasKey($key, $phpDoc->Vars);
@@ -374,7 +375,7 @@ final class PhpDocTest extends TestCase
             ```php
             callback(string $value): string
             ```
-            EOF, $this->eolToNative($phpDoc->Description));
+            EOF, Str::eolToNative($phpDoc->Description));
         $this->assertCount(1, $phpDoc->Vars);
         $this->assertSame(null, $phpDoc->Vars[0]->Name ?? null);
         $this->assertSame('?callable', $phpDoc->Vars[0]->Type ?? null);

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -2,7 +2,9 @@
 
 namespace Lkrms\Tests;
 
+use Lkrms\Console\Catalog\ConsoleLevel as Level;
 use Lkrms\Utility\Pcre;
+use Lkrms\Utility\Str;
 use Closure;
 use Throwable;
 
@@ -14,20 +16,42 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      * @param Closure(): mixed $callback
      * @param class-string<Throwable> $exception
      */
-    public function assertThrows(Closure $callback, string $exception, ?string $exceptionMessage = null, string $message = ''): void
-    {
+    public static function assertThrows(
+        Closure $callback,
+        string $exception,
+        ?string $exceptionMessage = null,
+        string $message = ''
+    ): void {
         try {
             $callback();
         } catch (Throwable $ex) {
-            $this->assertInstanceOf($exception, $ex, $message);
+            static::assertInstanceOf($exception, $ex, $message);
             if ($exceptionMessage !== null) {
-                $this->assertStringContainsString($exceptionMessage, $ex->getMessage(), $message);
+                static::assertStringContainsString($exceptionMessage, $ex->getMessage(), $message);
             }
             return;
         }
-        $this->fail($message === ''
+        static::fail($message === ''
             ? sprintf('Failed asserting that exception of type %s is thrown', $exception)
             : $message);
+    }
+
+    /**
+     * Assert that the given console messages are written, converting line
+     * endings if necessary
+     *
+     * @param array<array{Level::*,string,2?:array<string,mixed>}> $expected
+     * @param mixed[] $actual
+     */
+    public static function assertSameConsoleMessages(array $expected, array $actual, string $message = ''): void
+    {
+        foreach ($expected as $i => &$expectedMessage) {
+            $expectedMessage[1] = Str::eolFromNative($expectedMessage[1]);
+            if (!isset($expectedMessage[2]) && isset($actual[$i][2])) {
+                unset($actual[$i][2]);
+            }
+        }
+        static::assertEquals($expected, $actual, $message);
     }
 
     /**

--- a/tests/unit/TestCase.php
+++ b/tests/unit/TestCase.php
@@ -70,16 +70,6 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Replace newlines in a string with PHP_EOL
-     */
-    public static function eolToNative(?string $string): ?string
-    {
-        return $string === null
-            ? null
-            : str_replace("\n", \PHP_EOL, $string);
-    }
-
-    /**
      * Replace directory separators in a string with DIRECTORY_SEPARATOR
      */
     public static function directorySeparatorToNative(?string $string): ?string

--- a/tests/unit/Utility/ConvertTest.php
+++ b/tests/unit/Utility/ConvertTest.php
@@ -6,6 +6,7 @@ use Lkrms\Http\Uri;
 use Lkrms\Support\Date\DateFormatter;
 use Lkrms\Tests\TestCase;
 use Lkrms\Utility\Convert;
+use Lkrms\Utility\Str;
 use DateTimeImmutable;
 use DateTimeInterface;
 use ReflectionParameter;
@@ -384,7 +385,7 @@ final class ConvertTest extends TestCase
      */
     public function testLinesToLists(string $expected, ...$args): void
     {
-        $this->assertSame($expected, $this->eolToNative(Convert::linesToLists(...$args)));
+        $this->assertSame($expected, Str::eolToNative(Convert::linesToLists(...$args)));
     }
 
     /**

--- a/tests/unit/Utility/StrTest.php
+++ b/tests/unit/Utility/StrTest.php
@@ -32,6 +32,158 @@ final class StrTest extends TestCase
     }
 
     /**
+     * @dataProvider setEolProvider
+     */
+    public function testSetEol(string $expected, string $string, string $eol = "\n"): void
+    {
+        $this->assertSame($expected, Str::setEol($string, $eol));
+    }
+
+    /**
+     * @return array<array{string,string,2?:string}>
+     */
+    public static function setEolProvider(): array
+    {
+        return [
+            [
+                '',
+                '',
+            ],
+            [
+                "\n",
+                "\n",
+            ],
+            [
+                "\n",
+                "\r\n",
+            ],
+            [
+                "\r",
+                "\r\n",
+                "\r",
+            ],
+            [
+                "\r\r",
+                "\n\r",
+                "\r",
+            ],
+            [
+                "line1\nline2\n",
+                "line1\nline2\n",
+            ],
+            [
+                "line1\nline2\n",
+                "line1\r\nline2\r\n",
+            ],
+            [
+                "line1\nline2\n",
+                "line1\rline2\r",
+            ],
+            [
+                "line1\nline2\nline3\nline4\n\n",
+                "line1\r\nline2\nline3\rline4\n\r",
+            ],
+            [
+                "line1\rline2\rline3\rline4\r\r",
+                "line1\r\nline2\nline3\rline4\n\r",
+                "\r",
+            ],
+            [
+                "line1\r\nline2\r\nline3\r\nline4\r\n\r\n",
+                "line1\r\nline2\nline3\rline4\n\r",
+                "\r\n",
+            ],
+            [
+                "line1<br />\nline2<br />\nline3<br />\nline4<br />\n<br />\n",
+                "line1\r\nline2\nline3\rline4\n\r",
+                "<br />\n",
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider eolToNativeProvider
+     */
+    public function testEolToNative(?string $expected, ?string $string): void
+    {
+        $this->assertSame($expected, Str::eolToNative($string));
+    }
+
+    /**
+     * @return array<array{string,string}>
+     */
+    public static function eolToNativeProvider(): array
+    {
+        return [
+            [
+                null,
+                null,
+            ],
+            [
+                '',
+                '',
+            ],
+            [
+                <<<'EOF'
+
+
+                EOF,
+                "\n",
+            ],
+            [
+                <<<'EOF'
+                line1
+                line2
+
+
+                EOF,
+                "line1\nline2\n\n",
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider eolFromNativeProvider
+     */
+    public function testEolFromNative(?string $expected, ?string $string): void
+    {
+        $this->assertSame($expected, Str::eolFromNative($string));
+    }
+
+    /**
+     * @return array<array{string,string}>
+     */
+    public static function eolFromNativeProvider(): array
+    {
+        return [
+            [
+                null,
+                null,
+            ],
+            [
+                '',
+                '',
+            ],
+            [
+                "\n",
+                <<<'EOF'
+
+
+                EOF,
+            ],
+            [
+                "line1\nline2\n\n",
+                <<<'EOF'
+                line1
+                line2
+
+
+                EOF,
+            ],
+        ];
+    }
+
+    /**
      * @dataProvider caseConversionProvider
      */
     public function testCaseConversion(


### PR DESCRIPTION
- In `Str::setEol()`, normalise strings with multiple end-of-line sequences, reverting e07e050f
- Add `Str::eolToNative()`
- Replace multi-line strings in `Console` and `Cli` to ensure strings contain LF line breaks until output is generated
- Don't enable PCRE's Unicode flag unnecessarily in `ConsoleFormatter`