### PR TITLE
Console: improve stream target handling, incl. closing them on unload

### DIFF
--- a/src/Concept/Builder.php
+++ b/src/Concept/Builder.php
@@ -51,7 +51,7 @@ abstract class Builder extends FluentInterface implements IImmutable
     private array $Data = [];
 
     /**
-     * Creates a new builder
+     * Creates a new Builder object
      */
     final public function __construct(?IContainer $container = null)
     {

--- a/src/Concept/Provider.php
+++ b/src/Concept/Provider.php
@@ -20,7 +20,7 @@ abstract class Provider implements IProvider
     private DateFormatterInterface $DateFormatter;
 
     /**
-     * Creates a new provider object
+     * Creates a new Provider object
      */
     public function __construct(IContainer $app)
     {

--- a/src/Console/Concept/ConsolePrefixTarget.php
+++ b/src/Console/Concept/ConsolePrefixTarget.php
@@ -27,6 +27,8 @@ abstract class ConsolePrefixTarget extends ConsoleTarget implements ConsoleTarge
      */
     final public function write($level, string $message, array $context = []): void
     {
+        $this->assertIsValid();
+
         if ($this->Prefix === null) {
             $this->writeToTarget($level, $message, $context);
             return;
@@ -51,6 +53,8 @@ abstract class ConsolePrefixTarget extends ConsoleTarget implements ConsoleTarge
             return $this;
         }
 
+        $this->assertIsValid();
+
         $this->PrefixLength = strlen($prefix);
         $this->Prefix = $this->getFormatter()->getTagFormat(Tag::LOW_PRIORITY)->apply($prefix);
 
@@ -62,6 +66,8 @@ abstract class ConsolePrefixTarget extends ConsoleTarget implements ConsoleTarge
      */
     final public function getPrefix(): ?string
     {
+        $this->assertIsValid();
+
         return $this->Prefix;
     }
 
@@ -70,6 +76,8 @@ abstract class ConsolePrefixTarget extends ConsoleTarget implements ConsoleTarge
      */
     public function getWidth(): ?int
     {
+        $this->assertIsValid();
+
         return 80 - $this->PrefixLength;
     }
 }

--- a/src/Console/Concept/ConsoleTarget.php
+++ b/src/Console/Concept/ConsoleTarget.php
@@ -19,6 +19,8 @@ abstract class ConsoleTarget implements ConsoleTargetInterface
      */
     public function getFormatter(): Formatter
     {
+        $this->assertIsValid();
+
         return $this->Formatter ??= new Formatter(
             $this->createTagFormats(),
             $this->createMessageFormats(),
@@ -31,8 +33,17 @@ abstract class ConsoleTarget implements ConsoleTargetInterface
      */
     public function getWidth(): ?int
     {
+        $this->assertIsValid();
+
         return null;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function close(): void {}
+
+    protected function assertIsValid(): void {}
 
     protected function createTagFormats(): TagFormats
     {

--- a/src/Console/Contract/ConsoleTargetInterface.php
+++ b/src/Console/Contract/ConsoleTargetInterface.php
@@ -37,4 +37,9 @@ interface ConsoleTargetInterface
      * @param array<string,mixed> $context
      */
     public function write($level, string $message, array $context = []): void;
+
+    /**
+     * Close the target and any underlying resources
+     */
+    public function close(): void;
 }

--- a/src/Console/Contract/ConsoleTargetStreamInterface.php
+++ b/src/Console/Contract/ConsoleTargetStreamInterface.php
@@ -23,4 +23,9 @@ interface ConsoleTargetStreamInterface extends ConsoleTargetInterface
      * True if the target writes to a TTY
      */
     public function isTty(): bool;
+
+    /**
+     * Close and reopen the underlying PHP stream if possible
+     */
+    public function reopen(): void;
 }

--- a/src/Console/Exception/ConsoleInvalidTargetException.php
+++ b/src/Console/Exception/ConsoleInvalidTargetException.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\Console\Exception;
+
+use Lkrms\Exception\Exception;
+
+/**
+ * Thrown when a console output target receives a message after closing its
+ * underlying resources
+ */
+class ConsoleInvalidTargetException extends Exception {}

--- a/src/Contract/Unloadable.php
+++ b/src/Contract/Unloadable.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\Contract;
+
+interface Unloadable
+{
+    /**
+     * Close the object's underlying resources
+     */
+    public function unload(): void;
+}

--- a/src/Facade/Console.php
+++ b/src/Facade/Console.php
@@ -23,7 +23,8 @@ use Throwable;
  * @method static ConsoleWriter count(Level::* $level) Increment the message counter for $level without printing anything
  * @method static ConsoleWriter debug(string $msg1, ?string $msg2 = null, ?Throwable $ex = null, int $depth = 0) Print "--- {CALLER} $msg1 $msg2" with level DEBUG (see {@see ConsoleWriter::debug()})
  * @method static ConsoleWriter debugOnce(string $msg1, ?string $msg2 = null, ?Throwable $ex = null, int $depth = 0) Print "--- {CALLER} $msg1 $msg2" with level DEBUG once per run (see {@see ConsoleWriter::debugOnce()})
- * @method static ConsoleWriter deregisterTarget(Target $target) Deregister a previously registered target
+ * @method static ConsoleWriter deregisterAllTargets() Close and deregister all registered targets
+ * @method static ConsoleWriter deregisterTarget(Target $target) Close and deregister a previously registered target
  * @method static ConsoleWriter error(string $msg1, ?string $msg2 = null, ?Throwable $ex = null, bool $count = true) Print " !! $msg1 $msg2" with level ERROR
  * @method static ConsoleWriter errorOnce(string $msg1, ?string $msg2 = null, ?Throwable $ex = null, bool $count = true) Print " !! $msg1 $msg2" with level ERROR once per run
  * @method static ConsoleWriter exception(Throwable $exception, Level::* $messageLevel = Level::ERROR, Level::*|null $stackTraceLevel = Level::DEBUG) Report an uncaught exception (see {@see ConsoleWriter::exception()})
@@ -31,7 +32,7 @@ use Throwable;
  * @method static Formatter getFormatter(Level::* $level = Level::INFO) Get an output formatter for a registered target (see {@see ConsoleWriter::getFormatter()})
  * @method static TargetStream getStderrTarget() Get a target for STDERR, creating it if necessary
  * @method static TargetStream getStdoutTarget() Get a target for STDOUT, creating it if necessary
- * @method static Target[] getTargets() Get a list of registered output targets
+ * @method static Target[] getTargets() Get a list of registered targets
  * @method static int getWarnings() Get the number of warnings reported so far
  * @method static int|null getWidth(Level::* $level = Level::INFO) Get the width of a registered target in columns (see {@see ConsoleWriter::getWidth()})
  * @method static ConsoleWriter group(string $msg1, ?string $msg2 = null) Create a new message group and print "<<< $msg1 $msg2" with level NOTICE (see {@see ConsoleWriter::group()})

--- a/src/Support/Date/DateFormatParser.php
+++ b/src/Support/Date/DateFormatParser.php
@@ -15,7 +15,7 @@ final class DateFormatParser implements DateParserInterface
     private string $Format;
 
     /**
-     * Creates a new CreateFromFormatDateParser object
+     * Creates a new DateFormatParser object
      *
      * @see DateTimeImmutable::createFromFormat()
      */

--- a/src/Support/Introspector.php
+++ b/src/Support/Introspector.php
@@ -142,7 +142,7 @@ class Introspector
     }
 
     /**
-     * Creates a new introspector object
+     * Creates a new Introspector object
      *
      * @param class-string $service
      * @param class-string<TClass> $class

--- a/src/Sync/Concept/SyncProvider.php
+++ b/src/Sync/Concept/SyncProvider.php
@@ -67,7 +67,7 @@ abstract class SyncProvider extends Provider implements ISyncProvider, IService
     private $MagicMethodClosures = [];
 
     /**
-     * Creates a new provider object
+     * Creates a new SyncProvider object
      *
      * Creating an instance of the provider registers it with the entity store
      * injected by the container.

--- a/src/Utility/File.php
+++ b/src/Utility/File.php
@@ -454,11 +454,21 @@ final class File extends Utility
      */
     public static function same(string $filename1, string $filename2): bool
     {
-        if (!file_exists($filename1) || !file_exists($filename2)) {
+        if (!file_exists($filename1)) {
             return false;
         }
+
+        if ($filename1 === $filename2) {
+            return true;
+        }
+
+        if (!file_exists($filename2)) {
+            return false;
+        }
+
         $stat1 = self::stat($filename1);
         $stat2 = self::stat($filename2);
+
         return
             $stat1['dev'] === $stat2['dev'] &&
             $stat1['ino'] === $stat2['ino'];


### PR DESCRIPTION
- Add `Unloadable` interface
- If a facade's underlying instance implements `Unloadable`, call its `unload()` method before removing it from the facade
- Add `ConsoleTargetInterface::close()`
- Add `ConsoleTargetStreamInterface::reopen()`
- Add `Console::deregisterAllTargets()` and call it when the `Console` facade's underlying `ConsoleWriter` is unloaded
- In `Console::deregisterTarget()`, call `close()` on targets before deregistering them
- Add `ConsoleInvalidTargetException`
- Review `StreamTarget`
- In `File::same()`, return earlier if filenames are identical
- Update constructor summaries
- Fix issue where the first underlying instance loaded by `Facade` is never completely unloaded because its container event listener is never removed
- Fix issue where `Facade::unloadAll()` bypasses deregistrations applied in `Facade::unload()`