### PR TITLE
Cli: fix issue where `IsBound` is true for unbound options

### DIFF
--- a/src/Cli/CliOption.php
+++ b/src/Cli/CliOption.php
@@ -384,7 +384,7 @@ final class CliOption implements Buildable, HasJsonSchema, IImmutable, IReadable
             $this->Visibility |= CliOptionVisibility::SCHEMA;
         }
 
-        if (func_num_args() >= 20) {
+        if (func_num_args() >= 22) {
             $this->BindTo = &$bindTo;
             $this->IsBound = true;
         } else {


### PR DESCRIPTION
- Add test that fails when `CliOption` binds to a variable when `$bindTo` is not given