### PR TITLE
Fix `AbstractFacade::unload()` issues and improve documentation

### DIFF
--- a/src/Toolkit/Core/AbstractFacade.php
+++ b/src/Toolkit/Core/AbstractFacade.php
@@ -129,7 +129,7 @@ abstract class AbstractFacade implements FacadeInterface
                     $container->hasInstance($serviceName) &&
                     $container->get($serviceName) === $instance
                 ) {
-                    $container->unbind($serviceName);
+                    $container->unbindInstance($serviceName);
                 }
             }
         }

--- a/src/Toolkit/Core/Concern/HasFacade.php
+++ b/src/Toolkit/Core/Concern/HasFacade.php
@@ -89,7 +89,10 @@ trait HasFacade
 
         // Keep a copy of the cloned instance for future reuse if the facade is
         // not being unloaded
-        if (!$unloading) {
+        if ($unloading) {
+            $instance->InstanceWithoutFacade = null;
+            $instance->InstanceWithFacade = null;
+        } else {
             $instance->InstanceWithoutFacade = $instance;
             $instance->InstanceWithFacade = $this;
         }

--- a/src/Toolkit/Core/Contract/FacadeInterface.php
+++ b/src/Toolkit/Core/Contract/FacadeInterface.php
@@ -7,11 +7,6 @@ use LogicException;
 /**
  * Provides a static interface to an underlying instance
  *
- * Underlying instances that implement {@see FacadeAwareInterface} are replaced
- * with the object returned by {@see FacadeAwareInterface::withFacade()}, and
- * its {@see FacadeAwareInterface::withoutFacade()} method is used to service
- * the facade's {@see swap()}, {@see unload()} and {@see getInstance()} methods.
- *
  * @api
  *
  * @template TService of object
@@ -28,6 +23,10 @@ interface FacadeInterface
      *
      * If `$instance` is `null`, the facade creates a new underlying instance.
      *
+     * Then, if the instance implements {@see FacadeAwareInterface}, it is
+     * replaced with the return value of
+     * {@see FacadeAwareInterface::withFacade()}.
+     *
      * @param TService|null $instance
      * @throws LogicException if the facade's underlying instance is already
      * loaded.
@@ -37,12 +36,22 @@ interface FacadeInterface
     /**
      * Replace the facade's underlying instance
      *
+     * Equivalent to calling {@see unload()} before passing `$instance` to
+     * {@see load()}.
+     *
      * @param TService $instance
      */
     public static function swap(object $instance): void;
 
     /**
      * Remove the facade's underlying instance if loaded
+     *
+     * If the underlying instance implements {@see FacadeAwareInterface}, it is
+     * replaced with the return value of
+     * {@see FacadeAwareInterface::withoutFacade()}.
+     *
+     * Then, if the instance implements {@see Unloadable}, its
+     * {@see Unloadable::unload()} method is called.
      */
     public static function unload(): void;
 

--- a/src/Util/Container/ContainerInterface.php
+++ b/src/Util/Container/ContainerInterface.php
@@ -41,12 +41,12 @@ use Salient\Core\Contract\Unloadable;
 interface ContainerInterface extends PsrContainerInterface, Unloadable
 {
     /**
-     * Creates a new service container object
+     * Creates a new service container
      */
     public function __construct();
 
     /**
-     * True if the global container is set
+     * Check if the global container is set
      */
     public static function hasGlobalContainer(): bool;
 
@@ -117,28 +117,35 @@ interface ContainerInterface extends PsrContainerInterface, Unloadable
     public function getName(string $id): string;
 
     /**
-     * True if a service is bound to the container
+     * Check if a service is bound to the container
      *
      * @param class-string $id
      */
     public function has(string $id): bool;
 
     /**
-     * True if a service provider is registered with the container
+     * Check if a service provider is registered with the container
      *
      * @param class-string $id
      */
     public function hasProvider(string $id): bool;
 
     /**
-     * True if a service resolves to a shared instance
+     * Check if a shared service is bound to the container
+     *
+     * @param class-string $id
+     */
+    public function hasSingleton(string $id): bool;
+
+    /**
+     * Check if a service resolves to a shared instance
      *
      * @param class-string $id
      */
     public function hasInstance(string $id): bool;
 
     /**
-     * Register a binding with the container
+     * Bind a service to the container
      *
      * Subsequent requests for `$id` resolve to `$class`.
      *
@@ -162,7 +169,7 @@ interface ContainerInterface extends PsrContainerInterface, Unloadable
     ): self;
 
     /**
-     * Register a binding with the container if it isn't already registered
+     * Bind a service to the container if it isn't already bound
      *
      * @template TService of object
      * @template T of TService
@@ -179,7 +186,7 @@ interface ContainerInterface extends PsrContainerInterface, Unloadable
     ): self;
 
     /**
-     * Register a shared binding with the container
+     * Bind a shared service to the container
      *
      * Subsequent requests for `$id` resolve to the instance of `$class` created
      * when `$id` is first requested.
@@ -199,8 +206,7 @@ interface ContainerInterface extends PsrContainerInterface, Unloadable
     ): self;
 
     /**
-     * Register a shared binding with the container if it isn't already
-     * registered
+     * Bind a shared service to the container if it isn't already bound
      *
      * @template TService of object
      * @template T of TService
@@ -296,7 +302,7 @@ interface ContainerInterface extends PsrContainerInterface, Unloadable
     public function getProviders(): array;
 
     /**
-     * Register an object with the container as a shared binding
+     * Bind a shared instance to the container
      *
      * @template TService of object
      * @template T of TService
@@ -308,8 +314,7 @@ interface ContainerInterface extends PsrContainerInterface, Unloadable
     public function instance(string $id, $instance): self;
 
     /**
-     * Register an object with the container as a shared binding if it isn't
-     * already registered
+     * Bind a shared instance to the container if it isn't already bound
      *
      * @template TService of object
      * @template T of TService
@@ -327,4 +332,12 @@ interface ContainerInterface extends PsrContainerInterface, Unloadable
      * @return $this
      */
     public function unbind(string $id): self;
+
+    /**
+     * Remove a shared instance from the container
+     *
+     * @param class-string $id
+     * @return $this
+     */
+    public function unbindInstance(string $id): self;
 }

--- a/src/Util/Container/ContainerInterface.php
+++ b/src/Util/Container/ContainerInterface.php
@@ -124,13 +124,6 @@ interface ContainerInterface extends PsrContainerInterface, Unloadable
     public function has(string $id): bool;
 
     /**
-     * Check if a service provider is registered with the container
-     *
-     * @param class-string $id
-     */
-    public function hasProvider(string $id): bool;
-
-    /**
      * Check if a shared service is bound to the container
      *
      * @param class-string $id
@@ -143,6 +136,13 @@ interface ContainerInterface extends PsrContainerInterface, Unloadable
      * @param class-string $id
      */
     public function hasInstance(string $id): bool;
+
+    /**
+     * Check if a service provider is registered with the container
+     *
+     * @param class-string $id
+     */
+    public function hasProvider(string $id): bool;
 
     /**
      * Bind a service to the container
@@ -223,6 +223,30 @@ interface ContainerInterface extends PsrContainerInterface, Unloadable
     ): self;
 
     /**
+     * Bind a shared instance to the container
+     *
+     * @template TService of object
+     * @template T of TService
+     *
+     * @param class-string<TService> $id
+     * @param T $instance
+     * @return $this
+     */
+    public function instance(string $id, $instance): self;
+
+    /**
+     * Bind a shared instance to the container if it isn't already bound
+     *
+     * @template TService of object
+     * @template T of TService
+     *
+     * @param class-string<TService> $id
+     * @param T $instance
+     * @return $this
+     */
+    public function instanceIf(string $id, $instance): self;
+
+    /**
      * Register a contextual binding with the container
      *
      * Subsequent requests from `$context` for `$dependency` resolve to
@@ -300,30 +324,6 @@ interface ContainerInterface extends PsrContainerInterface, Unloadable
      * @return array<class-string>
      */
     public function getProviders(): array;
-
-    /**
-     * Bind a shared instance to the container
-     *
-     * @template TService of object
-     * @template T of TService
-     *
-     * @param class-string<TService> $id
-     * @param T $instance
-     * @return $this
-     */
-    public function instance(string $id, $instance): self;
-
-    /**
-     * Bind a shared instance to the container if it isn't already bound
-     *
-     * @template TService of object
-     * @template T of TService
-     *
-     * @param class-string<TService> $id
-     * @param T $instance
-     * @return $this
-     */
-    public function instanceIf(string $id, $instance): self;
 
     /**
      * Remove a binding from the container

--- a/src/Util/Facade/App.php
+++ b/src/Util/Facade/App.php
@@ -11,26 +11,28 @@ use Salient\Core\AbstractFacade;
  * A facade for the global service container
  *
  * @method static ContainerInterface addContextualBinding(class-string[]|class-string $context, class-string|string $dependency, (callable($this): mixed)|class-string|mixed $value) Register a contextual binding with the container (see {@see ContainerInterface::addContextualBinding()})
- * @method static ContainerInterface bind(class-string $id, class-string|null $class = null, mixed[] $args = []) Register a binding with the container (see {@see ContainerInterface::bind()})
- * @method static ContainerInterface bindIf(class-string $id, class-string|null $class = null, mixed[] $args = []) Register a binding with the container if it isn't already registered
+ * @method static ContainerInterface bind(class-string $id, class-string|null $class = null, mixed[] $args = []) Bind a service to the container (see {@see ContainerInterface::bind()})
+ * @method static ContainerInterface bindIf(class-string $id, class-string|null $class = null, mixed[] $args = []) Bind a service to the container if it isn't already bound
  * @method static object get(class-string $id, mixed[] $args = []) Resolve a service from the container (see {@see ContainerInterface::get()})
  * @method static object getAs(class-string $id, class-string $service, mixed[] $args = []) Resolve a partially-resolved service from the container (see {@see ContainerInterface::getAs()})
  * @method static ContainerInterface getGlobalContainer() Get the global container, creating it if necessary
  * @method static class-string getName(class-string $id) Resolve a service from the container to a concrete class name
  * @method static array<class-string> getProviders() Get a list of service providers registered with the container
- * @method static bool has(class-string $id) True if a service is bound to the container (see {@see ContainerInterface::has()})
- * @method static bool hasGlobalContainer() True if the global container is set
- * @method static bool hasInstance(class-string $id) True if a service resolves to a shared instance
- * @method static bool hasProvider(class-string $id) True if a service provider is registered with the container
+ * @method static bool has(class-string $id) Check if a service is bound to the container (see {@see ContainerInterface::has()})
+ * @method static bool hasGlobalContainer() Check if the global container is set
+ * @method static bool hasInstance(class-string $id) Check if a service resolves to a shared instance
+ * @method static bool hasProvider(class-string $id) Check if a service provider is registered with the container
+ * @method static bool hasSingleton(class-string $id) Check if a shared service is bound to the container
  * @method static ContainerInterface inContextOf(class-string $id) Apply the contextual bindings of a service to a copy of the container
- * @method static ContainerInterface instance(class-string $id, object $instance) Register an object with the container as a shared binding
- * @method static ContainerInterface instanceIf(class-string $id, object $instance) Register an object with the container as a shared binding if it isn't already registered
+ * @method static ContainerInterface instance(class-string $id, object $instance) Bind a shared instance to the container
+ * @method static ContainerInterface instanceIf(class-string $id, object $instance) Bind a shared instance to the container if it isn't already bound
  * @method static ContainerInterface provider(class-string $id, class-string[]|null $services = null, class-string[] $exceptServices = [], ServiceLifetime::* $lifetime = ServiceLifetime::INHERIT) Register a service provider with the container, optionally specifying which of its services to bind or ignore (see {@see ContainerInterface::provider()})
  * @method static ContainerInterface providers(array<class-string,class-string> $serviceMap, ServiceLifetime::* $lifetime = ServiceLifetime::INHERIT) Register a service map with the container (see {@see ContainerInterface::providers()})
  * @method static void setGlobalContainer(?ContainerInterface $container) Set or unset the global container
- * @method static ContainerInterface singleton(class-string $id, class-string|null $class = null, mixed[] $args = []) Register a shared binding with the container (see {@see ContainerInterface::singleton()})
- * @method static ContainerInterface singletonIf(class-string $id, class-string|null $class = null, mixed[] $args = []) Register a shared binding with the container if it isn't already registered
+ * @method static ContainerInterface singleton(class-string $id, class-string|null $class = null, mixed[] $args = []) Bind a shared service to the container (see {@see ContainerInterface::singleton()})
+ * @method static ContainerInterface singletonIf(class-string $id, class-string|null $class = null, mixed[] $args = []) Bind a shared service to the container if it isn't already bound
  * @method static ContainerInterface unbind(class-string $id) Remove a binding from the container
+ * @method static ContainerInterface unbindInstance(class-string $id) Remove a shared instance from the container
  *
  * @api
  *

--- a/tests/unit/Toolkit/Core/AbstractFacadeTest.php
+++ b/tests/unit/Toolkit/Core/AbstractFacadeTest.php
@@ -93,6 +93,18 @@ final class AbstractFacadeTest extends TestCase
         $this->assertTrue(MyClassFacade::isLoaded());
         MyClassFacade::unload();
         $this->assertSame([$instance], MyServiceClass::getUnloaded());
+
+        $this->assertFalse(MyInterfaceFacade::isLoaded());
+        $instance = MyInterfaceFacade::getInstance();
+        $this->assertTrue(MyInterfaceFacade::isLoaded());
+        $this->assertInstanceOf(MyHasFacadeClass::class, $instance);
+        MyInterfaceFacade::unload();
+        $unloaded = MyHasFacadeClass::getUnloaded();
+        $this->assertCount(1, $unloaded);
+        $unloaded = reset($unloaded);
+        $this->assertInstanceOf(MyHasFacadeClass::class, $unloaded);
+        $this->assertNotSame($instance, $unloaded);
+        $this->assertSame(2, $unloaded->getClones());
     }
 
     public function testUnloadNotLoaded(): void

--- a/tests/unit/Util/Container/ContainerTest.php
+++ b/tests/unit/Util/Container/ContainerTest.php
@@ -10,8 +10,10 @@ use Lkrms\Container\Container;
 use Lkrms\Container\ContainerInterface;
 use Lkrms\Container\ServiceLifetime;
 use Lkrms\Contract\IFluentInterface;
+use Lkrms\Facade\App;
 use Lkrms\Tests\TestCase;
 use Psr\Container\ContainerInterface as PsrContainerInterface;
+use stdClass;
 
 final class ContainerTest extends TestCase
 {
@@ -51,6 +53,50 @@ final class ContainerTest extends TestCase
             [ApplicationInterface::class],
             [Application::class],
         ];
+    }
+
+    public function testHasSingleton(): void
+    {
+        $container = new Container();
+        $this->assertFalse($container->hasSingleton(stdClass::class));
+        $container->bind(stdClass::class);
+        $this->assertFalse($container->hasSingleton(stdClass::class));
+
+        $container = new Container();
+        $container->instance(stdClass::class, new stdClass());
+        $this->assertTrue($container->hasSingleton(stdClass::class));
+        $container->unbindInstance(stdClass::class);
+        $this->assertFalse($container->hasInstance(stdClass::class));
+        $this->assertFalse($container->hasSingleton(stdClass::class));
+
+        $container = new Container();
+        $container->singleton(stdClass::class);
+        $this->assertTrue($container->hasSingleton(stdClass::class));
+        $container->get(stdClass::class);
+        $this->assertTrue($container->hasInstance(stdClass::class));
+        $container->unbindInstance(stdClass::class);
+        $this->assertFalse($container->hasInstance(stdClass::class));
+        $this->assertTrue($container->hasSingleton(stdClass::class));
+    }
+
+    public function testUnload(): void
+    {
+        $container = new Container();
+        $container->instance(stdClass::class, new stdClass());
+        $this->assertTrue($container->has(stdClass::class));
+        $container->unload();
+        $this->assertFalse($container->has(stdClass::class));
+    }
+
+    public function testUnloadWithFacade(): void
+    {
+        $container = App::getInstance();
+        $container->instance(stdClass::class, new stdClass());
+        $this->assertTrue(App::isLoaded());
+        $this->assertTrue($container->has(stdClass::class));
+        $container->unload();
+        $this->assertFalse(App::isLoaded());
+        $this->assertFalse($container->has(stdClass::class));
     }
 
     public function testServiceTransient(): void


### PR DESCRIPTION
- Fix issue where `HasFacade` doesn't remove references to cloned instances when unloaded
- Fix issue where service container bindings are forgotten when a facade's underlying instance is removed from a container
- Add service container methods `hasSingleton()` and `unbindInstance()`
- Leave `unload()`ed containers in a usable state
- Add tests