### PR TITLE
Sync: prevent infinite recursion during entity hydration

### DIFF
--- a/lk-util/Command/Generate/Concept/GenerateCommand.php
+++ b/lk-util/Command/Generate/Concept/GenerateCommand.php
@@ -200,7 +200,7 @@ abstract class GenerateCommand extends Command
     protected string $InputClassType;
 
     /**
-     * @var Introspector<object,Provider,Entity,ProviderContext>
+     * @var Introspector<object,Provider,Entity,ProviderContext<Provider,Entity>>
      */
     protected Introspector $InputIntrospector;
 

--- a/src/Util/Concept/Builder.php
+++ b/src/Util/Concept/Builder.php
@@ -40,7 +40,7 @@ abstract class Builder implements Chainable, Immutable
     protected ContainerInterface $Container;
 
     /**
-     * @var Introspector<object,Provider,Entity,ProviderContext>
+     * @var Introspector<object,Provider,Entity,ProviderContext<Provider,Entity>>
      */
     private Introspector $Introspector;
 

--- a/src/Util/Concept/Entity.php
+++ b/src/Util/Concept/Entity.php
@@ -8,6 +8,6 @@ use Lkrms\Support\ProviderContext;
 /**
  * Base class for entities
  *
- * @implements IProviderEntity<Provider,ProviderContext>
+ * @implements IProviderEntity<Provider,ProviderContext<Provider,self>>
  */
 abstract class Entity implements IProviderEntity {}

--- a/src/Util/Concept/Provider.php
+++ b/src/Util/Concept/Provider.php
@@ -4,6 +4,7 @@ namespace Lkrms\Concept;
 
 use Lkrms\Container\ContainerInterface;
 use Lkrms\Contract\IProvider;
+use Lkrms\Contract\IProviderContext;
 use Lkrms\Support\Date\DateFormatterInterface;
 use Lkrms\Support\ProviderContext;
 use Salient\Core\Exception\MethodNotImplementedException;
@@ -11,7 +12,7 @@ use Salient\Core\Exception\MethodNotImplementedException;
 /**
  * Base class for providers
  *
- * @implements IProvider<ProviderContext>
+ * @implements IProvider<ProviderContext<static,Entity>>
  */
 abstract class Provider implements IProvider
 {
@@ -39,11 +40,9 @@ abstract class Provider implements IProvider
     /**
      * @inheritDoc
      */
-    public function getContext(?ContainerInterface $container = null): ProviderContext
+    public function getContext(?ContainerInterface $container = null): IProviderContext
     {
-        if (!$container) {
-            $container = $this->App;
-        }
+        $container ??= $this->App;
 
         return $container->get(ProviderContext::class, [$this]);
     }
@@ -81,17 +80,15 @@ abstract class Provider implements IProvider
      */
     final public function dateFormatter(): DateFormatterInterface
     {
-        return $this->DateFormatter
-            ?? ($this->DateFormatter = $this->getDateFormatter());
+        return $this->DateFormatter ??= $this->getDateFormatter();
     }
 
     /**
-     * Get the date formatter cached by dateFormatter(), or null if it hasn't
-     * been cached
+     * Check if the date formatter returned by dateFormatter() has been cached
      */
-    final protected function getCachedDateFormatter(): ?DateFormatterInterface
+    final protected function hasDateFormatter(): bool
     {
-        return $this->DateFormatter ?? null;
+        return isset($this->DateFormatter);
     }
 
     /**

--- a/src/Util/Support/Introspector.php
+++ b/src/Util/Support/Introspector.php
@@ -107,7 +107,7 @@ class Introspector
      * @template T of object
      *
      * @param class-string<T> $service
-     * @return static<T,Provider,Entity,ProviderContext>
+     * @return static<T,Provider,Entity,ProviderContext<Provider,Entity>>
      */
     public static function getService(ContainerInterface $container, string $service)
     {
@@ -126,7 +126,7 @@ class Introspector
      * @template T of object
      *
      * @param class-string<T> $class
-     * @return static<T,Provider,Entity,ProviderContext>
+     * @return static<T,Provider,Entity,ProviderContext<Provider,Entity>>
      */
     public static function get(string $class)
     {

--- a/src/Util/Support/ProviderContext.php
+++ b/src/Util/Support/ProviderContext.php
@@ -14,9 +14,13 @@ use Salient\Core\Utility\Get;
 use Salient\Core\Utility\Str;
 
 /**
- * The context within which an entity is instantiated by a provider
+ * The context within which entities of a given type are instantiated by a
+ * provider
  *
- * @implements IProviderContext<IProvider<static>,IProvidable<IProvider<static>,static>>
+ * @template TProvider of IProvider
+ * @template TEntity of IProvidable
+ *
+ * @implements IProviderContext<TProvider,TEntity>
  */
 class ProviderContext implements IProviderContext
 {
@@ -25,12 +29,12 @@ class ProviderContext implements IProviderContext
     protected ContainerInterface $Container;
 
     /**
-     * @var IProvider<static>
+     * @var TProvider
      */
     protected IProvider $Provider;
 
     /**
-     * @var array<IProvidable<IProvider<static>,static>>
+     * @var TEntity[]
      */
     protected array $Stack = [];
 
@@ -40,7 +44,7 @@ class ProviderContext implements IProviderContext
     protected array $Values = [];
 
     /**
-     * @var (IProvidable<IProvider<static>,static>&ITreeable)|null
+     * @var (TEntity&ITreeable)|null
      */
     protected ?ITreeable $Parent = null;
 
@@ -52,7 +56,7 @@ class ProviderContext implements IProviderContext
     /**
      * Creates a new ProviderContext object
      *
-     * @param IProvider<static> $provider
+     * @param TProvider $provider
      */
     public function __construct(
         ContainerInterface $container,

--- a/src/Util/Sync/Command/GetSyncEntities.php
+++ b/src/Util/Sync/Command/GetSyncEntities.php
@@ -6,6 +6,7 @@ use Lkrms\Cli\Catalog\CliOptionType;
 use Lkrms\Cli\Exception\CliInvalidArgumentsException;
 use Lkrms\Cli\CliOption;
 use Lkrms\Facade\Console;
+use Lkrms\Sync\Catalog\DeferralPolicy;
 use Lkrms\Sync\Catalog\HydrationPolicy;
 use Lkrms\Sync\Contract\ISyncEntity;
 use Lkrms\Sync\Contract\ISyncProvider;
@@ -84,7 +85,7 @@ final class GetSyncEntities extends AbstractSyncCommand
                 ->bindTo($this->Filter),
             CliOption::build()
                 ->long('shallow')
-                ->description('Do not hydrate entity relationships')
+                ->description('Do not resolve entity relationships')
                 ->bindTo($this->Shallow),
             CliOption::build()
                 ->long('include-canonical-id')
@@ -148,7 +149,9 @@ final class GetSyncEntities extends AbstractSyncCommand
 
         $context = $provider->getContext();
         if ($this->Shallow || $this->Csv) {
-            $context = $context->withHydrationPolicy(HydrationPolicy::SUPPRESS);
+            $context = $context
+                ->withDeferralPolicy(DeferralPolicy::DO_NOT_RESOLVE)
+                ->withHydrationPolicy(HydrationPolicy::SUPPRESS);
         }
 
         $result = $this->EntityId !== null

--- a/src/Util/Sync/Concept/SyncDefinition.php
+++ b/src/Util/Sync/Concept/SyncDefinition.php
@@ -325,12 +325,13 @@ abstract class SyncDefinition implements ISyncDefinition, Chainable, Readable
 
         // If a method has been declared for this operation, use it, even if
         // it's not in $this->Operations
-        if ($closure =
-                $this->ProviderIntrospector->getDeclaredSyncOperationClosure(
-                    $operation,
-                    $this->EntityIntrospector,
-                    $this->Provider
-                )) {
+        $closure = $this->ProviderIntrospector->getDeclaredSyncOperationClosure(
+            $operation,
+            $this->EntityIntrospector,
+            $this->Provider
+        );
+
+        if ($closure) {
             return $this->Closures[$operation] =
                 fn(ISyncContext $ctx, ...$args) =>
                     $closure(
@@ -344,10 +345,9 @@ abstract class SyncDefinition implements ISyncDefinition, Chainable, Readable
                 ($closure = $this->getSyncOperationClosure(OP::READ_LIST))) {
             return $this->Closures[$operation] =
                 function (ISyncContext $ctx, $id, ...$args) use ($closure) {
-                    $entity =
-                        $this
-                            ->getFluentIterator($closure($ctx, ...$args))
-                            ->nextWithValue('Id', $id);
+                    $entity = $this
+                        ->getFluentIterator($closure($ctx, ...$args))
+                        ->nextWithValue('Id', $id);
                     if ($entity === null) {
                         throw new SyncEntityNotFoundException($this->Provider, $this->Entity, $id);
                     }

--- a/src/Util/Sync/Concept/SyncProvider.php
+++ b/src/Util/Sync/Concept/SyncProvider.php
@@ -83,7 +83,7 @@ abstract class SyncProvider extends Provider implements ISyncProvider, HasServic
     /**
      * @inheritDoc
      */
-    public function getContext(?ContainerInterface $container = null): SyncContext
+    public function getContext(?ContainerInterface $container = null): ISyncContext
     {
         if (!$container) {
             $container = $this->App;
@@ -249,10 +249,14 @@ abstract class SyncProvider extends Provider implements ISyncProvider, HasServic
      */
     final public function with(string $entity, $context = null): SyncEntityProvider
     {
-        /** @var ContainerInterface */
-        $container = $context instanceof ISyncContext
-            ? $context->container()
-            : ($context ?: $this->App);
+        if ($context instanceof ISyncContext) {
+            $context->maybeThrowRecursionException();
+            $container = $context->container();
+        } else {
+            /** @var ContainerInterface */
+            $container = $context ?? $this->App;
+        }
+
         $container = $container->inContextOf(static::class);
 
         $context = $context instanceof ISyncContext

--- a/src/Util/Sync/Exception/SyncEntityRecursionException.php
+++ b/src/Util/Sync/Exception/SyncEntityRecursionException.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Lkrms\Sync\Exception;
+
+/**
+ * Thrown when entity hydration triggers infinite recursion
+ */
+class SyncEntityRecursionException extends SyncException {}

--- a/src/Util/Sync/Support/SyncIntrospector.php
+++ b/src/Util/Sync/Support/SyncIntrospector.php
@@ -687,11 +687,13 @@ final class SyncIntrospector extends Introspector
                 $isParent,
                 $isChildren
             ): void {
-                if ($data[$key] === null ||
-                        (Arr::isList($data[$key]) xor $isList) ||
-                        !($entity instanceof ISyncEntity) ||
-                        !($provider instanceof ISyncProvider) ||
-                        !($context instanceof ISyncContext)) {
+                if (
+                    $data[$key] === null ||
+                    (Arr::isList($data[$key]) xor $isList) ||
+                    !($entity instanceof ISyncEntity) ||
+                    !($provider instanceof ISyncProvider) ||
+                    !($context instanceof ISyncContext)
+                ) {
                     $entity->{$property} = $data[$key];
                     return;
                 }
@@ -701,7 +703,7 @@ final class SyncIntrospector extends Introspector
                         if (!$isChildren) {
                             DeferredEntity::deferList(
                                 $provider,
-                                $context->push($entity),
+                                $context->pushWithRecursionCheck($entity),
                                 $relationship,
                                 $data[$key],
                                 $entity->{$property},
@@ -712,7 +714,7 @@ final class SyncIntrospector extends Introspector
                         /** @var ISyncEntity&ITreeable $entity */
                         DeferredEntity::deferList(
                             $provider,
-                            $context->push($entity),
+                            $context->pushWithRecursionCheck($entity),
                             $relationship,
                             $data[$key],
                             $replace,
@@ -749,7 +751,7 @@ final class SyncIntrospector extends Introspector
                     if (!$isParent) {
                         DeferredEntity::defer(
                             $provider,
-                            $context->push($entity),
+                            $context->pushWithRecursionCheck($entity),
                             $relationship,
                             $data[$key],
                             $entity->{$property},
@@ -760,7 +762,7 @@ final class SyncIntrospector extends Introspector
                     /** @var ISyncEntity&ITreeable $entity */
                     DeferredEntity::defer(
                         $provider,
-                        $context->push($entity),
+                        $context->pushWithRecursionCheck($entity),
                         $relationship,
                         $data[$key],
                         $replace,
@@ -822,9 +824,12 @@ final class SyncIntrospector extends Introspector
                 $entityType,
                 $entityProvider
             ): void {
-                if (!($context instanceof ISyncContext) ||
-                        !($provider instanceof ISyncProvider) ||
-                        !is_a($provider, $entityProvider)) {
+                if (
+                    !($context instanceof ISyncContext) ||
+                    !($provider instanceof ISyncProvider) ||
+                    !is_a($provider, $entityProvider) ||
+                    $data[$idKey] === null
+                ) {
                     return;
                 }
 
@@ -840,7 +845,7 @@ final class SyncIntrospector extends Introspector
                 if (!$isChildren) {
                     DeferredRelationship::defer(
                         $provider,
-                        $context->push($entity),
+                        $context->pushWithRecursionCheck($entity),
                         $relationship,
                         $service ?? $entityType,
                         $property,
@@ -854,7 +859,7 @@ final class SyncIntrospector extends Introspector
                 /** @var ISyncEntity&ITreeable $entity */
                 DeferredRelationship::defer(
                     $provider,
-                    $context->push($entity),
+                    $context->pushWithRecursionCheck($entity),
                     $relationship,
                     $service ?? $entityType,
                     $property,


### PR DESCRIPTION
- Add `SyncEntityRecursionException`
- Add `ISyncContext::pushWithRecursionCheck()` and use it instead of `ISyncContext::push()` where necessary to prevent recursive deferral of entities and relationships
- Add `ISyncContext::maybeThrowRecursionException()` and call it before requesting entities from providers
- In `GetSyncEntities`, apply `DeferralPolicy::DO_NOT_RESOLVE` in addition to `HydrationPolicy::SUPPRESS` when `--shallow` is given
- Fix issue where deferred relationships are created to hydrate entities with no identifier
- Update return types and PHPDoc annotations to resolve method compatibility issues reported by PHPStan